### PR TITLE
Add interpreter to day 2

### DIFF
--- a/mps-workshop-2-itemis/.mps/migration.xml
+++ b/mps-workshop-2-itemis/.mps/migration.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MigrationProperties">
+    <entry key="jetbrains.mps.ide.mpsmigration.v172.JUnitLibsRepackaging" value="executed" />
+  </component>
+</project>

--- a/mps-workshop-2-itemis/.mps/misc.xml
+++ b/mps-workshop-2-itemis/.mps/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MPSFavoritesManager">
+    <option name="keepMe" value="true" />
+  </component>
+</project>

--- a/mps-workshop-2-itemis/.mps/modules.xml
+++ b/mps-workshop-2-itemis/.mps/modules.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="MPSProject">
+    <projectModules>
+      <modulePath path="$PROJECT_DIR$/languages/mps.workshop.lang/mps.workshop.lang.mpl" folder="" />
+      <modulePath path="$PROJECT_DIR$/solutions/mps.workshop.executor/mps.workshop.executor.msd" folder="" />
+      <modulePath path="$PROJECT_DIR$/solutions/mps.workshop.interpreter/mps.workshop.interpreter.msd" folder="" />
+      <modulePath path="$PROJECT_DIR$/solutions/mps.workshop.runtime/mps.workshop.runtime.msd" folder="" />
+      <modulePath path="$PROJECT_DIR$/tests/mps.workshop.test/mps.workshop.test.msd" folder="" />
+    </projectModules>
+  </component>
+</project>

--- a/mps-workshop-2-itemis/.mps/vcs.xml
+++ b/mps-workshop-2-itemis/.mps/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/mps-workshop-2-itemis/.mps/version.xml
+++ b/mps-workshop-2-itemis/.mps/version.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectVersion">
+    <option name="version" value="3.1" />
+  </component>
+</project>

--- a/mps-workshop-2-itemis/languages/mps.workshop.lang/generator/template/main@generator.mps
+++ b/mps-workshop-2-itemis/languages/mps.workshop.lang/generator/template/main@generator.mps
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:d2c95bec-e30c-44de-a27b-3d1946647bef(main@generator)">
+  <persistence version="9" />
+  <languages>
+    <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
+    <devkit ref="a2eb3a43-fcc2-4200-80dc-c60110c4862d(jetbrains.mps.devkit.templates)" />
+  </languages>
+  <imports>
+    <import index="85g0" ref="r:3255fe94-9102-4828-b2d9-432a6ecad106(mps.workshop.lang.structure)" />
+    <import index="z390" ref="r:b22c5d7d-a0df-49ab-afea-c323c4910fc1(mps.workshop.runtime.plugin)" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
+  </imports>
+  <registry>
+    <language id="13744753-c81f-424a-9c1b-cf8943bf4e86" name="jetbrains.mps.lang.sharedConcepts">
+      <concept id="1161622665029" name="jetbrains.mps.lang.sharedConcepts.structure.ConceptFunctionParameter_model" flags="nn" index="1Q6Npb" />
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <property id="1176718929932" name="isFinal" index="3TUv4t" />
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+    </language>
+    <language id="b401a680-8325-4110-8fd3-84331ff25bef" name="jetbrains.mps.lang.generator">
+      <concept id="1095416546421" name="jetbrains.mps.lang.generator.structure.MappingConfiguration" flags="ig" index="bUwia">
+        <child id="1195502100749" name="preMappingScript" index="1puA0r" />
+      </concept>
+      <concept id="1195499912406" name="jetbrains.mps.lang.generator.structure.MappingScript" flags="lg" index="1pmfR0">
+        <property id="1195595592106" name="scriptKind" index="1v3f2W" />
+        <property id="1195595611951" name="modifiesModel" index="1v3jST" />
+        <child id="1195501105008" name="codeBlock" index="1pqMTA" />
+      </concept>
+      <concept id="1195500722856" name="jetbrains.mps.lang.generator.structure.MappingScript_CodeBlock" flags="in" index="1pplIY" />
+      <concept id="1195502151594" name="jetbrains.mps.lang.generator.structure.MappingScriptReference" flags="lg" index="1puMqW">
+        <reference id="1195502167610" name="mappingScript" index="1puQsG" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1171315804604" name="jetbrains.mps.lang.smodel.structure.Model_RootsOperation" flags="nn" index="2RRcyG">
+        <reference id="1171315804605" name="concept" index="2RRcyH" />
+      </concept>
+      <concept id="1206482823744" name="jetbrains.mps.lang.smodel.structure.Model_AddRootOperation" flags="nn" index="3BYIHo">
+        <child id="1206482823746" name="nodeArgument" index="3BYIHq" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
+        <child id="1153944400369" name="variable" index="2Gsz3X" />
+        <child id="1153944424730" name="inputSequence" index="2GsD0m" />
+      </concept>
+      <concept id="1153944193378" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariable" flags="nr" index="2GrKxI" />
+      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
+        <reference id="1153944258490" name="variable" index="2Gs0qQ" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="bUwia" id="Juyp1w2IV4">
+    <property role="TrG5h" value="main" />
+    <node concept="1puMqW" id="7P2vbT3qezO" role="1puA0r">
+      <ref role="1puQsG" node="7P2vbT3q0v1" resolve="compilation" />
+    </node>
+  </node>
+  <node concept="1pmfR0" id="7P2vbT3q0v1">
+    <property role="TrG5h" value="compilation" />
+    <property role="1v3f2W" value="pre_processing" />
+    <property role="1v3jST" value="true" />
+    <node concept="1pplIY" id="7P2vbT3q0v2" role="1pqMTA">
+      <node concept="3clFbS" id="7P2vbT3q0v3" role="2VODD2">
+        <node concept="2Gpval" id="7P2vbT3q1lj" role="3cqZAp">
+          <node concept="2GrKxI" id="7P2vbT3q1ll" role="2Gsz3X">
+            <property role="TrG5h" value="worksheet" />
+          </node>
+          <node concept="2OqwBi" id="7P2vbT3q2mF" role="2GsD0m">
+            <node concept="1Q6Npb" id="7P2vbT3qTsH" role="2Oq$k0" />
+            <node concept="2RRcyG" id="7P2vbT3q2rF" role="2OqNvi">
+              <ref role="2RRcyH" to="85g0:Juyp1w2Jt3" resolve="WWorksheet" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="7P2vbT3q1lp" role="2LFqv$">
+            <node concept="3cpWs8" id="7P2vbT3q2vP" role="3cqZAp">
+              <node concept="3cpWsn" id="7P2vbT3q2vQ" role="3cpWs9">
+                <property role="TrG5h" value="clazz" />
+                <property role="3TUv4t" value="true" />
+                <node concept="3Tqbb2" id="7P2vbT3q2vG" role="1tU5fm">
+                  <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+                </node>
+                <node concept="2YIFZM" id="7P2vbT3q2vR" role="33vP2m">
+                  <ref role="37wK5l" to="z390:4jnZTahjrwC" resolve="compileWorksheet" />
+                  <ref role="1Pybhc" to="z390:4jnZTahfvSp" resolve="Compiler" />
+                  <node concept="2GrUjf" id="7P2vbT3q2vS" role="37wK5m">
+                    <ref role="2Gs0qQ" node="7P2vbT3q1ll" resolve="worksheet" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="7P2vbT3q2OM" role="3cqZAp">
+              <node concept="2OqwBi" id="7P2vbT3q2W8" role="3clFbG">
+                <node concept="1Q6Npb" id="7P2vbT3qTov" role="2Oq$k0" />
+                <node concept="3BYIHo" id="7P2vbT3q34Y" role="2OqNvi">
+                  <node concept="37vLTw" id="7P2vbT3q35p" role="3BYIHq">
+                    <ref role="3cqZAo" node="7P2vbT3q2vQ" resolve="clazz" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/mps-workshop-2-itemis/languages/mps.workshop.lang/models/behavior.mps
+++ b/mps-workshop-2-itemis/languages/mps.workshop.lang/models/behavior.mps
@@ -1,0 +1,381 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:8c11527c-f00f-4af2-9187-3917731b6126(mps.workshop.lang.behavior)">
+  <persistence version="9" />
+  <languages>
+    <use id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior" version="1" />
+    <use id="daafa647-f1f7-4b0b-b096-69cd7c8408c0" name="jetbrains.mps.baseLanguage.regexp" version="0" />
+    <devkit ref="2677cb18-f558-4e33-bc38-a5139cee06dc(jetbrains.mps.devkit.language-design)" />
+  </languages>
+  <imports>
+    <import index="85g0" ref="r:3255fe94-9102-4828-b2d9-432a6ecad106(mps.workshop.lang.structure)" implicit="true" />
+    <import index="tpfp" ref="r:00000000-0000-4000-0000-011c89590519(jetbrains.mps.baseLanguage.regexp.jetbrains.mps.regexp.accessory)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="af65afd8-f0dd-4942-87d9-63a55f2a9db1" name="jetbrains.mps.lang.behavior">
+      <concept id="1225194240794" name="jetbrains.mps.lang.behavior.structure.ConceptBehavior" flags="ng" index="13h7C7">
+        <reference id="1225194240799" name="concept" index="13h7C2" />
+        <child id="1225194240805" name="method" index="13h7CS" />
+        <child id="1225194240801" name="constructor" index="13h7CW" />
+      </concept>
+      <concept id="1225194413805" name="jetbrains.mps.lang.behavior.structure.ConceptConstructorDeclaration" flags="in" index="13hLZK" />
+      <concept id="1225194472830" name="jetbrains.mps.lang.behavior.structure.ConceptMethodDeclaration" flags="ng" index="13i0hz">
+        <property id="5864038008284099149" name="isStatic" index="2Ki8OM" />
+        <property id="1225194472832" name="isVirtual" index="13i0it" />
+        <property id="1225194472834" name="isAbstract" index="13i0iv" />
+        <reference id="1225194472831" name="overriddenMethod" index="13i0hy" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534370425" name="jetbrains.mps.baseLanguage.structure.IntegerType" flags="in" index="10Oyi0" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <property id="1176718929932" name="isFinal" index="3TUv4t" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1068580320020" name="jetbrains.mps.baseLanguage.structure.IntegerConstant" flags="nn" index="3cmrfG">
+        <property id="1068580320021" name="value" index="3cmrfH" />
+      </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="daafa647-f1f7-4b0b-b096-69cd7c8408c0" name="jetbrains.mps.baseLanguage.regexp">
+      <concept id="1222260469397" name="jetbrains.mps.baseLanguage.regexp.structure.MatchRegexpOperation" flags="nn" index="2kpEY9" />
+      <concept id="1174482753837" name="jetbrains.mps.baseLanguage.regexp.structure.StringLiteralRegexp" flags="ng" index="1OC9wW">
+        <property id="1174482761807" name="text" index="1OCb_u" />
+      </concept>
+      <concept id="1174482804200" name="jetbrains.mps.baseLanguage.regexp.structure.PlusRegexp" flags="ng" index="1OClNT" />
+      <concept id="1174482808826" name="jetbrains.mps.baseLanguage.regexp.structure.StarRegexp" flags="ng" index="1OCmVF" />
+      <concept id="1174484562151" name="jetbrains.mps.baseLanguage.regexp.structure.SeqRegexp" flags="ng" index="1OJ37Q" />
+      <concept id="1174485167097" name="jetbrains.mps.baseLanguage.regexp.structure.BinaryRegexp" flags="ng" index="1OLmFC">
+        <child id="1174485176897" name="left" index="1OLpdg" />
+        <child id="1174485181039" name="right" index="1OLqdY" />
+      </concept>
+      <concept id="1174485235885" name="jetbrains.mps.baseLanguage.regexp.structure.UnaryRegexp" flags="ng" index="1OLBAW">
+        <child id="1174485243418" name="regexp" index="1OLDsb" />
+      </concept>
+      <concept id="1174491169200" name="jetbrains.mps.baseLanguage.regexp.structure.ParensRegexp" flags="ng" index="1P8g2x">
+        <child id="1174491174779" name="expr" index="1P8hpE" />
+      </concept>
+      <concept id="1174510540317" name="jetbrains.mps.baseLanguage.regexp.structure.InlineRegexpExpression" flags="nn" index="1Qi9sc">
+        <child id="1174510571016" name="regexp" index="1QigWp" />
+      </concept>
+      <concept id="1174552240608" name="jetbrains.mps.baseLanguage.regexp.structure.QuestionRegexp" flags="ng" index="1SLe3L" />
+      <concept id="1174554186090" name="jetbrains.mps.baseLanguage.regexp.structure.SymbolClassRegexp" flags="ng" index="1SSD1V">
+        <child id="1174557628217" name="part" index="1T5LoC" />
+      </concept>
+      <concept id="1174554211468" name="jetbrains.mps.baseLanguage.regexp.structure.PositiveSymbolClassRegexp" flags="ng" index="1SSJmt" />
+      <concept id="1174555732504" name="jetbrains.mps.baseLanguage.regexp.structure.PredefinedSymbolClassRegexp" flags="ng" index="1SYyG9">
+        <reference id="1174555843709" name="symbolClass" index="1SYXPG" />
+      </concept>
+      <concept id="1174558301835" name="jetbrains.mps.baseLanguage.regexp.structure.IntervalSymbolClassPart" flags="ng" index="1T8lYq">
+        <property id="1174558315290" name="start" index="1T8p8b" />
+        <property id="1174558317822" name="end" index="1T8pRJ" />
+      </concept>
+      <concept id="1174653354106" name="jetbrains.mps.baseLanguage.regexp.structure.RegexpUsingConstruction" flags="ng" index="1YMW5F">
+        <child id="1174653387388" name="regexp" index="1YN4dH" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="13h7C7" id="Juyp1w2SZb">
+    <ref role="13h7C2" to="85g0:Juyp1w2Jt3" resolve="Worksheet" />
+    <node concept="13hLZK" id="Juyp1w2SZc" role="13h7CW">
+      <node concept="3clFbS" id="Juyp1w2SZd" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="Juyp1w2TBP">
+    <property role="3GE5qa" value="expression" />
+    <ref role="13h7C2" to="85g0:Juyp1w2Ti3" resolve="NumberLiteral" />
+    <node concept="13i0hz" id="4rZeNQ6OfoS" role="13h7CS">
+      <property role="TrG5h" value="isZero" />
+      <property role="2Ki8OM" value="true" />
+      <node concept="3Tm1VV" id="4rZeNQ6OfoT" role="1B3o_S" />
+      <node concept="10P_77" id="4rZeNQ6Ofp0" role="3clF45" />
+      <node concept="3clFbS" id="4rZeNQ6OfoV" role="3clF47">
+        <node concept="3cpWs6" id="6Mx2TmozOvM" role="3cqZAp">
+          <node concept="1Wc70l" id="6Mx2TmozOvN" role="3cqZAk">
+            <node concept="3y3z36" id="6Mx2TmozOvO" role="3uHU7B">
+              <node concept="10Nm6u" id="6Mx2TmozOvP" role="3uHU7w" />
+              <node concept="37vLTw" id="6Mx2TmozOvQ" role="3uHU7B">
+                <ref role="3cqZAo" node="4rZeNQ6Ogy7" resolve="val" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6Mx2TmozOvR" role="3uHU7w">
+              <node concept="37vLTw" id="6Mx2TmozOvS" role="2Oq$k0">
+                <ref role="3cqZAo" node="4rZeNQ6Ogy7" resolve="val" />
+              </node>
+              <node concept="2kpEY9" id="6Mx2TmozOvT" role="2OqNvi">
+                <node concept="1Qi9sc" id="6Mx2TmozOvU" role="1YN4dH">
+                  <node concept="1OJ37Q" id="6Mx2TmozOvV" role="1QigWp">
+                    <node concept="1P8g2x" id="6Mx2TmozOvW" role="1OLpdg">
+                      <node concept="1SLe3L" id="6Mx2TmozOvX" role="1P8hpE">
+                        <node concept="1OC9wW" id="6Mx2TmozOvY" role="1OLDsb">
+                          <property role="1OCb_u" value="-" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="1OClNT" id="6Mx2TmozOvZ" role="1OLqdY">
+                      <node concept="1P8g2x" id="6Mx2TmozOw0" role="1OLDsb">
+                        <node concept="1OC9wW" id="6Mx2TmozOw1" role="1P8hpE">
+                          <property role="1OCb_u" value="0" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="4rZeNQ6Ogy7" role="3clF46">
+        <property role="TrG5h" value="val" />
+        <property role="3TUv4t" value="true" />
+        <node concept="17QB3L" id="4rZeNQ6Ogy6" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="4rZeNQ6Og4r" role="13h7CS">
+      <property role="TrG5h" value="isInteger" />
+      <property role="2Ki8OM" value="true" />
+      <node concept="3Tm1VV" id="4rZeNQ6Og4s" role="1B3o_S" />
+      <node concept="10P_77" id="4rZeNQ6Og4t" role="3clF45" />
+      <node concept="3clFbS" id="4rZeNQ6Og4u" role="3clF47">
+        <node concept="3cpWs6" id="6Mx2TmozOFg" role="3cqZAp">
+          <node concept="1Wc70l" id="6Mx2TmozOFh" role="3cqZAk">
+            <node concept="3y3z36" id="6Mx2TmozOFi" role="3uHU7B">
+              <node concept="10Nm6u" id="6Mx2TmozOFj" role="3uHU7w" />
+              <node concept="37vLTw" id="6Mx2TmozOFk" role="3uHU7B">
+                <ref role="3cqZAo" node="4rZeNQ6Ogz6" resolve="val" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6Mx2TmozOFl" role="3uHU7w">
+              <node concept="37vLTw" id="6Mx2TmozOFm" role="2Oq$k0">
+                <ref role="3cqZAo" node="4rZeNQ6Ogz6" resolve="val" />
+              </node>
+              <node concept="2kpEY9" id="6Mx2TmozOFn" role="2OqNvi">
+                <node concept="1Qi9sc" id="6Mx2TmozOFo" role="1YN4dH">
+                  <node concept="1OJ37Q" id="6Mx2TmozOFp" role="1QigWp">
+                    <node concept="1OJ37Q" id="6Mx2TmozOFq" role="1OLpdg">
+                      <node concept="1SSJmt" id="6Mx2TmozOFr" role="1OLqdY">
+                        <node concept="1T8lYq" id="6Mx2TmozOFs" role="1T5LoC">
+                          <property role="1T8p8b" value="1" />
+                          <property role="1T8pRJ" value="9" />
+                        </node>
+                      </node>
+                      <node concept="1P8g2x" id="6Mx2TmozOFt" role="1OLpdg">
+                        <node concept="1SLe3L" id="6Mx2TmozOFu" role="1P8hpE">
+                          <node concept="1OC9wW" id="6Mx2TmozOFv" role="1OLDsb">
+                            <property role="1OCb_u" value="-" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="1OCmVF" id="6Mx2TmozOFw" role="1OLqdY">
+                      <node concept="1SYyG9" id="6Mx2TmozOFx" role="1OLDsb">
+                        <ref role="1SYXPG" to="tpfp:h5SUwpi" resolve="\d" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="4rZeNQ6Ogz6" role="3clF46">
+        <property role="TrG5h" value="val" />
+        <property role="3TUv4t" value="true" />
+        <node concept="17QB3L" id="4rZeNQ6Ogz5" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="13i0hz" id="4rZeNQ6Og7j" role="13h7CS">
+      <property role="TrG5h" value="isReal" />
+      <property role="2Ki8OM" value="true" />
+      <node concept="3Tm1VV" id="4rZeNQ6Og7k" role="1B3o_S" />
+      <node concept="10P_77" id="4rZeNQ6Og7l" role="3clF45" />
+      <node concept="3clFbS" id="4rZeNQ6Og7m" role="3clF47">
+        <node concept="3cpWs6" id="6Mx2TmozOMZ" role="3cqZAp">
+          <node concept="1Wc70l" id="6Mx2TmozON0" role="3cqZAk">
+            <node concept="3y3z36" id="6Mx2TmozON1" role="3uHU7B">
+              <node concept="10Nm6u" id="6Mx2TmozON2" role="3uHU7w" />
+              <node concept="37vLTw" id="6Mx2TmozON3" role="3uHU7B">
+                <ref role="3cqZAo" node="4rZeNQ6OgzZ" resolve="val" />
+              </node>
+            </node>
+            <node concept="2OqwBi" id="6Mx2TmozON4" role="3uHU7w">
+              <node concept="37vLTw" id="6Mx2TmozON5" role="2Oq$k0">
+                <ref role="3cqZAo" node="4rZeNQ6OgzZ" resolve="val" />
+              </node>
+              <node concept="2kpEY9" id="6Mx2TmozON6" role="2OqNvi">
+                <node concept="1Qi9sc" id="6Mx2TmozON7" role="1YN4dH">
+                  <node concept="1OJ37Q" id="6Mx2TmozON8" role="1QigWp">
+                    <node concept="1P8g2x" id="6Mx2TmozON9" role="1OLpdg">
+                      <node concept="1SLe3L" id="6Mx2TmozONa" role="1P8hpE">
+                        <node concept="1OC9wW" id="6Mx2TmozONb" role="1OLDsb">
+                          <property role="1OCb_u" value="-" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="1OJ37Q" id="6Mx2TmozONc" role="1OLqdY">
+                      <node concept="1OCmVF" id="6Mx2TmozONd" role="1OLpdg">
+                        <node concept="1SYyG9" id="6Mx2TmozONe" role="1OLDsb">
+                          <ref role="1SYXPG" to="tpfp:h5SUwpi" resolve="\d" />
+                        </node>
+                      </node>
+                      <node concept="1OJ37Q" id="6Mx2TmozONf" role="1OLqdY">
+                        <node concept="1OCmVF" id="7fbn8D7pc2B" role="1OLqdY">
+                          <node concept="1SYyG9" id="7fbn8D7pc2D" role="1OLDsb">
+                            <ref role="1SYXPG" to="tpfp:h5SUwpi" resolve="\d" />
+                          </node>
+                        </node>
+                        <node concept="1OC9wW" id="6Mx2TmozONg" role="1OLpdg">
+                          <property role="1OCb_u" value="." />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="37vLTG" id="4rZeNQ6OgzZ" role="3clF46">
+        <property role="TrG5h" value="val" />
+        <property role="3TUv4t" value="true" />
+        <node concept="17QB3L" id="4rZeNQ6OgzY" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="13hLZK" id="Juyp1w2TBQ" role="13h7CW">
+      <node concept="3clFbS" id="Juyp1w2TBR" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="Juyp1w3F2Z">
+    <property role="3GE5qa" value="expression" />
+    <ref role="13h7C2" to="85g0:Juyp1w3DPP" resolve="BinaryExpression" />
+    <node concept="13i0hz" id="Juyp1w3F3a" role="13h7CS">
+      <property role="TrG5h" value="getPriority" />
+      <property role="13i0it" value="true" />
+      <property role="13i0iv" value="false" />
+      <property role="2Ki8OM" value="true" />
+      <node concept="3Tm1VV" id="Juyp1w3F3b" role="1B3o_S" />
+      <node concept="10Oyi0" id="Juyp1w3F3u" role="3clF45" />
+      <node concept="3clFbS" id="Juyp1w3F3d" role="3clF47">
+        <node concept="3cpWs6" id="Juyp1w3F4t" role="3cqZAp">
+          <node concept="3cmrfG" id="Juyp1w3F4N" role="3cqZAk">
+            <property role="3cmrfH" value="0" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13i0hz" id="Juyp1w3F57" role="13h7CS">
+      <property role="TrG5h" value="isLeftAssociative" />
+      <property role="13i0it" value="true" />
+      <property role="13i0iv" value="false" />
+      <property role="2Ki8OM" value="true" />
+      <node concept="3Tm1VV" id="Juyp1w3F58" role="1B3o_S" />
+      <node concept="10P_77" id="Juyp1w3F7k" role="3clF45" />
+      <node concept="3clFbS" id="Juyp1w3F5a" role="3clF47">
+        <node concept="3cpWs6" id="Juyp1w3F5b" role="3cqZAp">
+          <node concept="3clFbT" id="Juyp1w3FfZ" role="3cqZAk">
+            <property role="3clFbU" value="true" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="13hLZK" id="Juyp1w3F30" role="13h7CW">
+      <node concept="3clFbS" id="Juyp1w3F31" role="2VODD2" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="Juyp1w4oUP">
+    <property role="3GE5qa" value="expression" />
+    <ref role="13h7C2" to="85g0:Juyp1w4oUO" resolve="MulExpression" />
+    <node concept="13hLZK" id="Juyp1w4oUQ" role="13h7CW">
+      <node concept="3clFbS" id="Juyp1w4oUR" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="Juyp1w4oV0" role="13h7CS">
+      <property role="TrG5h" value="getPriority" />
+      <property role="13i0it" value="false" />
+      <property role="13i0iv" value="false" />
+      <property role="2Ki8OM" value="true" />
+      <ref role="13i0hy" node="Juyp1w3F3a" resolve="getPriority" />
+      <node concept="3Tm1VV" id="Juyp1w4oV1" role="1B3o_S" />
+      <node concept="3clFbS" id="Juyp1w4oV6" role="3clF47">
+        <node concept="3cpWs6" id="Juyp1w4oYO" role="3cqZAp">
+          <node concept="3cmrfG" id="Juyp1w4phQ" role="3cqZAk">
+            <property role="3cmrfH" value="1" />
+          </node>
+        </node>
+      </node>
+      <node concept="10Oyi0" id="Juyp1w4oV7" role="3clF45" />
+    </node>
+  </node>
+  <node concept="13h7C7" id="Juyp1w4pib">
+    <property role="3GE5qa" value="expression" />
+    <ref role="13h7C2" to="85g0:Juyp1w4pia" resolve="DivExpression" />
+    <node concept="13hLZK" id="Juyp1w4pic" role="13h7CW">
+      <node concept="3clFbS" id="Juyp1w4pid" role="2VODD2" />
+    </node>
+    <node concept="13i0hz" id="Juyp1w4pim" role="13h7CS">
+      <property role="TrG5h" value="getPriority" />
+      <property role="13i0it" value="false" />
+      <property role="13i0iv" value="false" />
+      <property role="2Ki8OM" value="true" />
+      <ref role="13i0hy" node="Juyp1w3F3a" resolve="getPriority" />
+      <node concept="3Tm1VV" id="Juyp1w4pin" role="1B3o_S" />
+      <node concept="3clFbS" id="Juyp1w4pis" role="3clF47">
+        <node concept="3cpWs6" id="Juyp1w4pmf" role="3cqZAp">
+          <node concept="3cmrfG" id="Juyp1w4pmm" role="3cqZAk">
+            <property role="3cmrfH" value="1" />
+          </node>
+        </node>
+      </node>
+      <node concept="10Oyi0" id="Juyp1w4pit" role="3clF45" />
+    </node>
+  </node>
+</model>
+

--- a/mps-workshop-2-itemis/languages/mps.workshop.lang/models/constraints.mps
+++ b/mps-workshop-2-itemis/languages/mps.workshop.lang/models/constraints.mps
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:b9683cf9-72f7-443a-8e39-08c0fa4c4415(mps.workshop.lang.constraints)">
+  <persistence version="9" />
+  <languages>
+    <use id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints" version="4" />
+    <devkit ref="00000000-0000-4000-0000-5604ebd4f22c(jetbrains.mps.devkit.aspect.constraints)" />
+  </languages>
+  <imports>
+    <import index="85g0" ref="r:3255fe94-9102-4828-b2d9-432a6ecad106(mps.workshop.lang.structure)" implicit="true" />
+    <import index="6r3z" ref="r:8c11527c-f00f-4af2-9187-3917731b6126(mps.workshop.lang.behavior)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+    </language>
+    <language id="3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1" name="jetbrains.mps.lang.constraints">
+      <concept id="1147467115080" name="jetbrains.mps.lang.constraints.structure.NodePropertyConstraint" flags="ng" index="EnEH3">
+        <reference id="1147467295099" name="applicableProperty" index="EomxK" />
+        <child id="1212097481299" name="propertyValidator" index="QCWH9" />
+      </concept>
+      <concept id="1212096972063" name="jetbrains.mps.lang.constraints.structure.ConstraintFunction_PropertyValidator" flags="in" index="QB0g5" />
+      <concept id="1213093968558" name="jetbrains.mps.lang.constraints.structure.ConceptConstraints" flags="ng" index="1M2fIO">
+        <reference id="1213093996982" name="concept" index="1M2myG" />
+        <child id="1213098023997" name="property" index="1MhHOB" />
+      </concept>
+      <concept id="1153138554286" name="jetbrains.mps.lang.constraints.structure.ConstraintsFunctionParameter_propertyValue" flags="nn" index="1Wqviy" />
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1M2fIO" id="Juyp1w2Tia">
+    <property role="3GE5qa" value="expression" />
+    <ref role="1M2myG" to="85g0:Juyp1w2Ti3" resolve="NumberLiteral" />
+    <node concept="EnEH3" id="Juyp1w2Tib" role="1MhHOB">
+      <ref role="EomxK" to="85g0:Juyp1w2Ti7" resolve="value" />
+      <node concept="QB0g5" id="Juyp1w2Tie" role="QCWH9">
+        <node concept="3clFbS" id="Juyp1w2Tif" role="2VODD2">
+          <node concept="3cpWs6" id="Juyp1w2UCs" role="3cqZAp">
+            <node concept="22lmx$" id="Juyp1w2UCt" role="3cqZAk">
+              <node concept="22lmx$" id="Juyp1w2UCy" role="3uHU7B">
+                <node concept="2OqwBi" id="Juyp1w36S1" role="3uHU7B">
+                  <node concept="35c_gC" id="Juyp1w36S2" role="2Oq$k0">
+                    <ref role="35c_gD" to="85g0:Juyp1w2Ti3" resolve="NumberLiteral" />
+                  </node>
+                  <node concept="2qgKlT" id="Juyp1w36S3" role="2OqNvi">
+                    <ref role="37wK5l" to="6r3z:4rZeNQ6OfoS" resolve="isZero" />
+                    <node concept="1Wqviy" id="Juyp1w36S4" role="37wK5m" />
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="Juyp1w370S" role="3uHU7w">
+                  <node concept="35c_gC" id="Juyp1w370T" role="2Oq$k0">
+                    <ref role="35c_gD" to="85g0:Juyp1w2Ti3" resolve="NumberLiteral" />
+                  </node>
+                  <node concept="2qgKlT" id="Juyp1w370U" role="2OqNvi">
+                    <ref role="37wK5l" to="6r3z:4rZeNQ6Og4r" resolve="isInteger" />
+                    <node concept="1Wqviy" id="Juyp1w370V" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="Juyp1w37hZ" role="3uHU7w">
+                <node concept="35c_gC" id="Juyp1w37i0" role="2Oq$k0">
+                  <ref role="35c_gD" to="85g0:Juyp1w2Ti3" resolve="NumberLiteral" />
+                </node>
+                <node concept="2qgKlT" id="Juyp1w37i1" role="2OqNvi">
+                  <ref role="37wK5l" to="6r3z:4rZeNQ6Og7j" resolve="isReal" />
+                  <node concept="1Wqviy" id="Juyp1w37i2" role="37wK5m" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/mps-workshop-2-itemis/languages/mps.workshop.lang/models/editor.mps
+++ b/mps-workshop-2-itemis/languages/mps.workshop.lang/models/editor.mps
@@ -1,0 +1,294 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:5a9841d8-363a-4715-80dd-8fd649ae116b(mps.workshop.lang.editor)">
+  <persistence version="9" />
+  <languages>
+    <use id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor" version="11" />
+    <use id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells" version="0" />
+    <devkit ref="2677cb18-f558-4e33-bc38-a5139cee06dc(jetbrains.mps.devkit.language-design)" />
+  </languages>
+  <imports>
+    <import index="85g0" ref="r:3255fe94-9102-4828-b2d9-432a6ecad106(mps.workshop.lang.structure)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+    <import index="6r3z" ref="r:8c11527c-f00f-4af2-9187-3917731b6126(mps.workshop.lang.behavior)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
+      <concept id="1071666914219" name="jetbrains.mps.lang.editor.structure.ConceptEditorDeclaration" flags="ig" index="24kQdi" />
+      <concept id="1176897764478" name="jetbrains.mps.lang.editor.structure.QueryFunction_NodeFactory" flags="in" index="4$FPG" />
+      <concept id="1140524381322" name="jetbrains.mps.lang.editor.structure.CellModel_ListWithRole" flags="ng" index="2czfm3">
+        <child id="1176897874615" name="nodeFactory" index="4_6I_" />
+        <child id="1140524464360" name="cellLayout" index="2czzBx" />
+      </concept>
+      <concept id="1237303669825" name="jetbrains.mps.lang.editor.structure.CellLayout_Indent" flags="nn" index="l2Vlx" />
+      <concept id="1237375020029" name="jetbrains.mps.lang.editor.structure.IndentLayoutNewLineChildrenStyleClassItem" flags="ln" index="pj6Ft" />
+      <concept id="1237385578942" name="jetbrains.mps.lang.editor.structure.IndentLayoutOnNewLineStyleClassItem" flags="ln" index="pVoyu" />
+      <concept id="1080736578640" name="jetbrains.mps.lang.editor.structure.BaseEditorComponent" flags="ig" index="2wURMF">
+        <child id="1080736633877" name="cellModel" index="2wV5jI" />
+      </concept>
+      <concept id="1186414536763" name="jetbrains.mps.lang.editor.structure.BooleanStyleSheetItem" flags="ln" index="VOi$J">
+        <property id="1186414551515" name="flag" index="VOm3f" />
+      </concept>
+      <concept id="1186414860679" name="jetbrains.mps.lang.editor.structure.EditableStyleClassItem" flags="ln" index="VPxyj" />
+      <concept id="1630016958697344083" name="jetbrains.mps.lang.editor.structure.IMenu_Concept" flags="ng" index="2ZABuq">
+        <reference id="6591946374543067572" name="conceptDeclaration" index="aqKnT" />
+      </concept>
+      <concept id="1233758997495" name="jetbrains.mps.lang.editor.structure.PunctuationLeftStyleClassItem" flags="ln" index="11L4FC" />
+      <concept id="1233759184865" name="jetbrains.mps.lang.editor.structure.PunctuationRightStyleClassItem" flags="ln" index="11LMrY" />
+      <concept id="3308396621974580100" name="jetbrains.mps.lang.editor.structure.SubstituteMenu_Default" flags="ng" index="3p36aQ" />
+      <concept id="1139848536355" name="jetbrains.mps.lang.editor.structure.CellModel_WithRole" flags="ng" index="1$h60E">
+        <reference id="1140103550593" name="relationDeclaration" index="1NtTu8" />
+      </concept>
+      <concept id="1073389446423" name="jetbrains.mps.lang.editor.structure.CellModel_Collection" flags="sn" stub="3013115976261988961" index="3EZMnI">
+        <child id="1106270802874" name="cellLayout" index="2iSdaV" />
+        <child id="1073389446424" name="childCellModel" index="3EZMnx" />
+      </concept>
+      <concept id="1073389577006" name="jetbrains.mps.lang.editor.structure.CellModel_Constant" flags="sn" stub="3610246225209162225" index="3F0ifn">
+        <property id="1073389577007" name="text" index="3F0ifm" />
+      </concept>
+      <concept id="1073389658414" name="jetbrains.mps.lang.editor.structure.CellModel_Property" flags="sg" stub="730538219796134133" index="3F0A7n" />
+      <concept id="1219418625346" name="jetbrains.mps.lang.editor.structure.IStyleContainer" flags="ng" index="3F0Thp">
+        <child id="1219418656006" name="styleItem" index="3F10Kt" />
+      </concept>
+      <concept id="1073389882823" name="jetbrains.mps.lang.editor.structure.CellModel_RefNode" flags="sg" stub="730538219795960754" index="3F1sOY" />
+      <concept id="1073390211982" name="jetbrains.mps.lang.editor.structure.CellModel_RefNodeList" flags="sg" stub="2794558372793454595" index="3F2HdR" />
+      <concept id="1166049232041" name="jetbrains.mps.lang.editor.structure.AbstractComponent" flags="ng" index="1XWOmA">
+        <reference id="1166049300910" name="conceptDeclaration" index="1XX52x" />
+      </concept>
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+      </concept>
+    </language>
+    <language id="9d69e719-78c8-4286-90db-fb19c107d049" name="com.mbeddr.mpsutil.grammarcells">
+      <concept id="1716599163375643733" name="com.mbeddr.mpsutil.grammarcells.structure.BracketsCell" flags="ng" index="drBAd">
+        <child id="1716599163375643743" name="left" index="drBA7" />
+        <child id="1716599163375643746" name="inner" index="drBAU" />
+        <child id="1716599163375643751" name="right" index="drBAZ" />
+      </concept>
+      <concept id="5083944728300220902" name="com.mbeddr.mpsutil.grammarcells.structure.SubstituteCell" flags="ng" index="yw3OH">
+        <child id="5083944728300220903" name="wrapped" index="yw3OG" />
+      </concept>
+      <concept id="8207263695490893775" name="com.mbeddr.mpsutil.grammarcells.structure.CellBasedRule" flags="ng" index="2ElW$n">
+        <child id="8207263695491669778" name="leftAssociative" index="2EmT7a" />
+        <child id="8207263695491670784" name="priority" index="2EmURo" />
+      </concept>
+      <concept id="8207263695491691232" name="com.mbeddr.mpsutil.grammarcells.structure.SubconceptExpression" flags="ng" index="2EmZKS" />
+      <concept id="7363578995839435357" name="com.mbeddr.mpsutil.grammarcells.structure.WrapperCell" flags="ng" index="1kIj98">
+        <child id="7363578995839435358" name="wrapped" index="1kIj9b" />
+      </concept>
+      <concept id="2862331529394479412" name="com.mbeddr.mpsutil.grammarcells.structure.GrammarConstantQuery" flags="ig" index="1Lj6DC" />
+      <concept id="2862331529394479405" name="com.mbeddr.mpsutil.grammarcells.structure.GrammarConstantQueryCell" flags="ng" index="1Lj6DL">
+        <child id="2862331529394487726" name="query" index="1Lj8FM" />
+      </concept>
+      <concept id="2862331529394480355" name="com.mbeddr.mpsutil.grammarcells.structure.Parameter_SubConcept" flags="ng" index="1Lj6YZ" />
+      <concept id="3011849438420226693" name="com.mbeddr.mpsutil.grammarcells.structure.GrammarInfoCell" flags="ng" index="1WcQYu">
+        <child id="8207263695490916687" name="rules" index="2El2Yn" />
+        <child id="2862331529394260612" name="projection" index="1LiK7o" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1179409122411" name="jetbrains.mps.lang.smodel.structure.Node_ConceptMethodCall" flags="nn" index="2qgKlT" />
+      <concept id="6870613620390542976" name="jetbrains.mps.lang.smodel.structure.ConceptAliasOperation" flags="ng" index="3n3YKJ" />
+      <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
+        <child id="1180636770616" name="createdType" index="3zrR0E" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="24kQdi" id="Juyp1w2Jtc">
+    <ref role="1XX52x" to="85g0:Juyp1w2Jt3" resolve="Worksheet" />
+    <node concept="3EZMnI" id="Juyp1w2Lr6" role="2wV5jI">
+      <node concept="3F0ifn" id="Juyp1w2LvG" role="3EZMnx">
+        <property role="3F0ifm" value="Worksheet" />
+      </node>
+      <node concept="3F0A7n" id="Juyp1w2Lwp" role="3EZMnx">
+        <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+      </node>
+      <node concept="l2Vlx" id="Juyp1w2Lr7" role="2iSdaV" />
+      <node concept="3F2HdR" id="Juyp1w2Jtl" role="3EZMnx">
+        <ref role="1NtTu8" to="85g0:Juyp1w2Jti" resolve="statements" />
+        <node concept="pVoyu" id="Juyp1w2LwT" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="l2Vlx" id="Juyp1w2Jtp" role="2czzBx" />
+        <node concept="pj6Ft" id="Juyp1w2KgQ" role="3F10Kt">
+          <property role="VOm3f" value="true" />
+        </node>
+        <node concept="4$FPG" id="Juyp1w2KgT" role="4_6I_">
+          <node concept="3clFbS" id="Juyp1w2KgU" role="2VODD2">
+            <node concept="3cpWs6" id="Juyp1w2Kkg" role="3cqZAp">
+              <node concept="2ShNRf" id="Juyp1w2KnQ" role="3cqZAk">
+                <node concept="3zrR0B" id="Juyp1w2Kky" role="2ShVmc">
+                  <node concept="3Tqbb2" id="Juyp1w2Kkz" role="3zrR0E">
+                    <ref role="ehGHo" to="85g0:Juyp1w2Jtf" resolve="EmptyStatement" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="Juyp1w2KSh">
+    <property role="3GE5qa" value="statement" />
+    <ref role="1XX52x" to="85g0:Juyp1w2Jtf" resolve="EmptyStatement" />
+    <node concept="3F0ifn" id="Juyp1w2KSj" role="2wV5jI">
+      <node concept="VPxyj" id="Juyp1w2KSn" role="3F10Kt">
+        <property role="VOm3f" value="true" />
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="Juyp1w2LZh">
+    <property role="3GE5qa" value="statement" />
+    <ref role="1XX52x" to="85g0:Juyp1w2Jtg" resolve="VariableDeclaration" />
+    <node concept="3EZMnI" id="Juyp1w2LZn" role="2wV5jI">
+      <node concept="l2Vlx" id="Juyp1w2LZo" role="2iSdaV" />
+      <node concept="3F0ifn" id="Juyp1w2LZj" role="3EZMnx">
+        <property role="3F0ifm" value="val" />
+      </node>
+      <node concept="3F0A7n" id="Juyp1w2LZA" role="3EZMnx">
+        <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
+      </node>
+      <node concept="3F0ifn" id="Juyp1w2LZN" role="3EZMnx">
+        <property role="3F0ifm" value="=" />
+      </node>
+      <node concept="3F1sOY" id="Juyp1w2M04" role="3EZMnx">
+        <ref role="1NtTu8" to="85g0:Juyp1w2LZ6" resolve="initializer" />
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="Juyp1w2M0w">
+    <property role="3GE5qa" value="statement" />
+    <ref role="1XX52x" to="85g0:Juyp1w2Jth" resolve="ExpressionStatement" />
+    <node concept="1kIj98" id="5o_AG9lOg9_" role="2wV5jI">
+      <node concept="3F1sOY" id="Juyp1w2M0y" role="1kIj9b">
+        <ref role="1NtTu8" to="85g0:Juyp1w2M0e" resolve="expression" />
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="Juyp1w2V2H">
+    <property role="3GE5qa" value="expression" />
+    <ref role="1XX52x" to="85g0:Juyp1w2Ti3" resolve="NumberLiteral" />
+    <node concept="1kIj98" id="53Tmle2rhiD" role="2wV5jI">
+      <node concept="3F0A7n" id="4AQJtfMIf16" role="1kIj9b">
+        <ref role="1NtTu8" to="85g0:Juyp1w2Ti7" resolve="value" />
+      </node>
+    </node>
+  </node>
+  <node concept="3p36aQ" id="Juyp1w2Xv_">
+    <property role="3GE5qa" value="statement" />
+    <ref role="aqKnT" to="85g0:Juyp1w2Jtf" resolve="EmptyStatement" />
+  </node>
+  <node concept="24kQdi" id="Juyp1w3DQ9">
+    <property role="3GE5qa" value="expression" />
+    <ref role="1XX52x" to="85g0:Juyp1w3DPP" resolve="BinaryExpression" />
+    <node concept="1WcQYu" id="4rZeNQ6MpLd" role="2wV5jI">
+      <node concept="2ElW$n" id="4rZeNQ6MpLf" role="2El2Yn">
+        <node concept="2OqwBi" id="4rZeNQ6Mq6$" role="2EmURo">
+          <node concept="2EmZKS" id="4rZeNQ6Mq4p" role="2Oq$k0" />
+          <node concept="2qgKlT" id="Juyp1w3HcL" role="2OqNvi">
+            <ref role="37wK5l" to="6r3z:Juyp1w3F3a" resolve="getPriority" />
+          </node>
+        </node>
+        <node concept="2OqwBi" id="4rZeNQ6Mqer" role="2EmT7a">
+          <node concept="2EmZKS" id="4rZeNQ6Mqc4" role="2Oq$k0" />
+          <node concept="2qgKlT" id="Juyp1w3GI8" role="2OqNvi">
+            <ref role="37wK5l" to="6r3z:Juyp1w3F57" resolve="isLeftAssociative" />
+          </node>
+        </node>
+      </node>
+      <node concept="3EZMnI" id="4rZeNQ6MpLp" role="1LiK7o">
+        <node concept="1kIj98" id="4rZeNQ6MpLw" role="3EZMnx">
+          <node concept="3F1sOY" id="4rZeNQ6MpLA" role="1kIj9b">
+            <ref role="1NtTu8" to="85g0:Juyp1w3DPT" resolve="left" />
+          </node>
+        </node>
+        <node concept="yw3OH" id="4rZeNQ6MpMS" role="3EZMnx">
+          <node concept="1Lj6DL" id="4rZeNQ6MpN6" role="yw3OG">
+            <node concept="1Lj6DC" id="4rZeNQ6MpN8" role="1Lj8FM">
+              <node concept="3clFbS" id="4rZeNQ6MpNa" role="2VODD2">
+                <node concept="3clFbF" id="4rZeNQ6MpNS" role="3cqZAp">
+                  <node concept="2OqwBi" id="4rZeNQ6MpQJ" role="3clFbG">
+                    <node concept="1Lj6YZ" id="4rZeNQ6MpNR" role="2Oq$k0" />
+                    <node concept="3n3YKJ" id="4rZeNQ6MpWP" role="2OqNvi" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="1kIj98" id="4rZeNQ6MpMB" role="3EZMnx">
+          <node concept="3F1sOY" id="4rZeNQ6MpMM" role="1kIj9b">
+            <ref role="1NtTu8" to="85g0:Juyp1w3DPW" resolve="right" />
+          </node>
+        </node>
+        <node concept="l2Vlx" id="4rZeNQ6MpLs" role="2iSdaV" />
+      </node>
+    </node>
+  </node>
+  <node concept="24kQdi" id="Juyp1w4RJ5">
+    <property role="3GE5qa" value="expression" />
+    <ref role="1XX52x" to="85g0:Juyp1w4RIQ" resolve="ParensExpression" />
+    <node concept="1WcQYu" id="Juyp1w4RJq" role="2wV5jI">
+      <node concept="2ElW$n" id="Juyp1w4RJs" role="2El2Yn" />
+      <node concept="drBAd" id="Juyp1w4RJD" role="1LiK7o">
+        <node concept="3F0ifn" id="Juyp1w4RJF" role="drBA7">
+          <property role="3F0ifm" value="(" />
+          <node concept="11LMrY" id="Juyp1w6S5a" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="3F1sOY" id="Juyp1w4RJH" role="drBAU">
+          <ref role="1NtTu8" to="85g0:Juyp1w4RIU" resolve="expression" />
+        </node>
+        <node concept="3F0ifn" id="Juyp1w4RJJ" role="drBAZ">
+          <property role="3F0ifm" value=")" />
+          <node concept="11L4FC" id="Juyp1w6S5h" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="3p36aQ" id="3avjRq3xs7s">
+    <property role="3GE5qa" value="expression" />
+    <ref role="aqKnT" to="85g0:Juyp1w3DPP" resolve="BinaryExpression" />
+  </node>
+  <node concept="3p36aQ" id="5o_AG9lP4Qt">
+    <property role="3GE5qa" value="expression" />
+    <ref role="aqKnT" to="85g0:Juyp1w2Ti3" resolve="NumberLiteral" />
+  </node>
+  <node concept="3p36aQ" id="4AQJtfMHLzX">
+    <property role="3GE5qa" value="statement" />
+    <ref role="aqKnT" to="85g0:Juyp1w2Jth" resolve="ExpressionStatement" />
+  </node>
+</model>
+

--- a/mps-workshop-2-itemis/languages/mps.workshop.lang/models/intentions.mps
+++ b/mps-workshop-2-itemis/languages/mps.workshop.lang/models/intentions.mps
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:420a9171-4393-4e4c-aec4-84a8d7dcdc06(mps.workshop.lang.intentions)">
+  <persistence version="9" />
+  <languages>
+    <use id="d7a92d38-f7db-40d0-8431-763b0c3c9f20" name="jetbrains.mps.lang.intentions" version="0" />
+    <use id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging" version="0" />
+    <use id="9ded098b-ad6a-4657-bfd9-48636cfe8bc3" name="jetbrains.mps.lang.traceable" version="0" />
+    <devkit ref="2677cb18-f558-4e33-bc38-a5139cee06dc(jetbrains.mps.devkit.language-design)" />
+  </languages>
+  <imports>
+    <import index="e4jo" ref="r:020f90a8-ee23-470d-af3e-0fbebdc45a9f(mps.workshop.interpreter.plugin)" />
+    <import index="of7k" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.util.messages.impl(MPS.IDEA/)" />
+    <import index="jkm4" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi.ui(MPS.IDEA/)" />
+    <import index="85g0" ref="r:3255fe94-9102-4828-b2d9-432a6ecad106(mps.workshop.lang.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+    </language>
+    <language id="d7a92d38-f7db-40d0-8431-763b0c3c9f20" name="jetbrains.mps.lang.intentions">
+      <concept id="1192794744107" name="jetbrains.mps.lang.intentions.structure.IntentionDeclaration" flags="ig" index="2S6QgY" />
+      <concept id="1192794782375" name="jetbrains.mps.lang.intentions.structure.DescriptionBlock" flags="in" index="2S6ZIM" />
+      <concept id="1192795911897" name="jetbrains.mps.lang.intentions.structure.ExecuteBlock" flags="in" index="2Sbjvc" />
+      <concept id="1192796902958" name="jetbrains.mps.lang.intentions.structure.ConceptFunctionParameter_node" flags="nn" index="2Sf5sV" />
+      <concept id="2522969319638091381" name="jetbrains.mps.lang.intentions.structure.BaseIntentionDeclaration" flags="ig" index="2ZfUlf">
+        <property id="2522969319638091386" name="isAvailableInChildNodes" index="2ZfUl0" />
+        <reference id="2522969319638198290" name="forConcept" index="2ZfgGC" />
+        <child id="2522969319638198291" name="executeFunction" index="2ZfgGD" />
+        <child id="2522969319638093993" name="descriptionFunction" index="2ZfVej" />
+      </concept>
+    </language>
+    <language id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging">
+      <concept id="6332851714983831325" name="jetbrains.mps.baseLanguage.logging.structure.MsgStatement" flags="ng" index="2xdQw9">
+        <property id="6332851714983843871" name="severity" index="2xdLsb" />
+        <child id="5721587534047265374" name="message" index="9lYJi" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="2S6QgY" id="2Xv3T3_hZLN">
+    <property role="3GE5qa" value="statement" />
+    <property role="TrG5h" value="interpret" />
+    <property role="2ZfUl0" value="true" />
+    <ref role="2ZfgGC" to="85g0:Juyp1w2Jte" resolve="Statement" />
+    <node concept="2S6ZIM" id="2Xv3T3_hZLO" role="2ZfVej">
+      <node concept="3clFbS" id="2Xv3T3_hZLP" role="2VODD2">
+        <node concept="3clFbF" id="2Xv3T3_i0y0" role="3cqZAp">
+          <node concept="Xl_RD" id="2Xv3T3_i0xZ" role="3clFbG">
+            <property role="Xl_RC" value="Interpret Statement" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2Sbjvc" id="2Xv3T3_hZLQ" role="2ZfgGD">
+      <node concept="3clFbS" id="2Xv3T3_hZLR" role="2VODD2">
+        <node concept="3cpWs8" id="2Xv3T3_i1K5" role="3cqZAp">
+          <node concept="3cpWsn" id="2Xv3T3_i1K6" role="3cpWs9">
+            <property role="TrG5h" value="eval" />
+            <node concept="17QB3L" id="2Xv3T3_i1K3" role="1tU5fm" />
+            <node concept="2YIFZM" id="2Xv3T3_i1K7" role="33vP2m">
+              <ref role="37wK5l" to="e4jo:2Xv3T3_hTVq" resolve="eval" />
+              <ref role="1Pybhc" to="e4jo:2Xv3T3_hTLQ" resolve="EvalHelper" />
+              <node concept="2Sf5sV" id="2Xv3T3_i1K8" role="37wK5m" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="2Xv3T3_iPCt" role="3cqZAp">
+          <node concept="2YIFZM" id="2Xv3T3_iPIq" role="3clFbG">
+            <ref role="37wK5l" to="jkm4:~Messages.showInfoMessage(java.lang.String,java.lang.String):void" resolve="showInfoMessage" />
+            <ref role="1Pybhc" to="jkm4:~Messages" resolve="Messages" />
+            <node concept="37vLTw" id="2Xv3T3_iPJH" role="37wK5m">
+              <ref role="3cqZAo" node="2Xv3T3_i1K6" resolve="eval" />
+            </node>
+            <node concept="Xl_RD" id="2Xv3T3_iPM4" role="37wK5m">
+              <property role="Xl_RC" value="Interpreted" />
+            </node>
+          </node>
+        </node>
+        <node concept="2xdQw9" id="2Xv3T3_i1SN" role="3cqZAp">
+          <property role="2xdLsb" value="info" />
+          <node concept="3cpWs3" id="2Xv3T3_i2cQ" role="9lYJi">
+            <node concept="37vLTw" id="2Xv3T3_i2dr" role="3uHU7w">
+              <ref role="3cqZAo" node="2Xv3T3_i1K6" resolve="eval" />
+            </node>
+            <node concept="Xl_RD" id="2Xv3T3_i1SP" role="3uHU7B">
+              <property role="Xl_RC" value="Interpreted: " />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+</model>
+

--- a/mps-workshop-2-itemis/languages/mps.workshop.lang/models/structure.mps
+++ b/mps-workshop-2-itemis/languages/mps.workshop.lang/models/structure.mps
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:3255fe94-9102-4828-b2d9-432a6ecad106(mps.workshop.lang.structure)">
+  <persistence version="9" />
+  <languages>
+    <use id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure" version="6" />
+    <devkit ref="78434eb8-b0e5-444b-850d-e7c4ad2da9ab(jetbrains.mps.devkit.aspect.structure)" />
+  </languages>
+  <imports>
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="c72da2b9-7cce-4447-8389-f407dc1158b7" name="jetbrains.mps.lang.structure">
+      <concept id="1169125787135" name="jetbrains.mps.lang.structure.structure.AbstractConceptDeclaration" flags="ig" index="PkWjJ">
+        <property id="6714410169261853888" name="conceptId" index="EcuMT" />
+        <property id="5092175715804935370" name="conceptAlias" index="34LRSv" />
+        <child id="1071489727083" name="linkDeclaration" index="1TKVEi" />
+        <child id="1071489727084" name="propertyDeclaration" index="1TKVEl" />
+      </concept>
+      <concept id="1169125989551" name="jetbrains.mps.lang.structure.structure.InterfaceConceptDeclaration" flags="ig" index="PlHQZ" />
+      <concept id="1169127622168" name="jetbrains.mps.lang.structure.structure.InterfaceConceptReference" flags="ig" index="PrWs8">
+        <reference id="1169127628841" name="intfc" index="PrY4T" />
+      </concept>
+      <concept id="1071489090640" name="jetbrains.mps.lang.structure.structure.ConceptDeclaration" flags="ig" index="1TIwiD">
+        <property id="1096454100552" name="rootable" index="19KtqR" />
+        <reference id="1071489389519" name="extends" index="1TJDcQ" />
+        <child id="1169129564478" name="implements" index="PzmwI" />
+      </concept>
+      <concept id="1071489288299" name="jetbrains.mps.lang.structure.structure.PropertyDeclaration" flags="ig" index="1TJgyi">
+        <property id="241647608299431129" name="propertyId" index="IQ2nx" />
+        <reference id="1082985295845" name="dataType" index="AX2Wp" />
+      </concept>
+      <concept id="1071489288298" name="jetbrains.mps.lang.structure.structure.LinkDeclaration" flags="ig" index="1TJgyj">
+        <property id="1071599776563" name="role" index="20kJfa" />
+        <property id="1071599893252" name="sourceCardinality" index="20lbJX" />
+        <property id="1071599937831" name="metaClass" index="20lmBu" />
+        <property id="241647608299431140" name="linkId" index="IQ2ns" />
+        <reference id="1071599976176" name="target" index="20lvS9" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1TIwiD" id="Juyp1w2Jt3">
+    <property role="EcuMT" value="855272232426600259" />
+    <property role="TrG5h" value="Worksheet" />
+    <property role="34LRSv" value="Worksheet" />
+    <property role="19KtqR" value="true" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="Juyp1w2Jti" role="1TKVEi">
+      <property role="IQ2ns" value="855272232426600274" />
+      <property role="20lmBu" value="aggregation" />
+      <property role="20kJfa" value="statements" />
+      <property role="20lbJX" value="0..n" />
+      <ref role="20lvS9" node="Juyp1w2Jte" resolve="Statement" />
+    </node>
+    <node concept="PrWs8" id="Juyp1w2Lr0" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+  </node>
+  <node concept="PlHQZ" id="Juyp1w2Jte">
+    <property role="EcuMT" value="855272232426600270" />
+    <property role="TrG5h" value="Statement" />
+    <property role="3GE5qa" value="statement" />
+  </node>
+  <node concept="1TIwiD" id="Juyp1w2Jtf">
+    <property role="EcuMT" value="855272232426600271" />
+    <property role="TrG5h" value="EmptyStatement" />
+    <property role="3GE5qa" value="statement" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="PrWs8" id="Juyp1w2La5" role="PzmwI">
+      <ref role="PrY4T" node="Juyp1w2Jte" resolve="Statement" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="Juyp1w2Jtg">
+    <property role="EcuMT" value="855272232426600272" />
+    <property role="TrG5h" value="VariableDeclaration" />
+    <property role="34LRSv" value="val" />
+    <property role="3GE5qa" value="statement" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="Juyp1w2LZ6" role="1TKVEi">
+      <property role="IQ2ns" value="855272232426610630" />
+      <property role="20lmBu" value="aggregation" />
+      <property role="20kJfa" value="initializer" />
+      <property role="20lbJX" value="1" />
+      <ref role="20lvS9" node="Juyp1w2LZ5" resolve="Expression" />
+    </node>
+    <node concept="PrWs8" id="Juyp1w2LYR" role="PzmwI">
+      <ref role="PrY4T" node="Juyp1w2Jte" resolve="Statement" />
+    </node>
+    <node concept="PrWs8" id="Juyp1w2LYZ" role="PzmwI">
+      <ref role="PrY4T" to="tpck:h0TrEE$" resolve="INamedConcept" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="Juyp1w2Jth">
+    <property role="EcuMT" value="855272232426600273" />
+    <property role="TrG5h" value="ExpressionStatement" />
+    <property role="3GE5qa" value="statement" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="Juyp1w2M0e" role="1TKVEi">
+      <property role="IQ2ns" value="855272232426610702" />
+      <property role="20lmBu" value="aggregation" />
+      <property role="20kJfa" value="expression" />
+      <property role="20lbJX" value="1" />
+      <ref role="20lvS9" node="Juyp1w2LZ5" resolve="Expression" />
+    </node>
+    <node concept="PrWs8" id="Juyp1w2M0k" role="PzmwI">
+      <ref role="PrY4T" node="Juyp1w2Jte" resolve="Statement" />
+    </node>
+  </node>
+  <node concept="PlHQZ" id="Juyp1w2LZ5">
+    <property role="EcuMT" value="855272232426610629" />
+    <property role="TrG5h" value="Expression" />
+    <property role="3GE5qa" value="expression" />
+  </node>
+  <node concept="1TIwiD" id="Juyp1w2Ti3">
+    <property role="EcuMT" value="855272232426640515" />
+    <property role="TrG5h" value="NumberLiteral" />
+    <property role="3GE5qa" value="expression" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyi" id="Juyp1w2Ti7" role="1TKVEl">
+      <property role="IQ2nx" value="855272232426640519" />
+      <property role="TrG5h" value="value" />
+      <ref role="AX2Wp" to="tpck:fKAOsGN" resolve="string" />
+    </node>
+    <node concept="PrWs8" id="Juyp1w2Ti4" role="PzmwI">
+      <ref role="PrY4T" node="Juyp1w2LZ5" resolve="Expression" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="Juyp1w3DPP">
+    <property role="EcuMT" value="855272232426839413" />
+    <property role="TrG5h" value="BinaryExpression" />
+    <property role="3GE5qa" value="expression" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="Juyp1w3DPT" role="1TKVEi">
+      <property role="IQ2ns" value="855272232426839417" />
+      <property role="20lmBu" value="aggregation" />
+      <property role="20kJfa" value="left" />
+      <property role="20lbJX" value="1" />
+      <ref role="20lvS9" node="Juyp1w2LZ5" resolve="Expression" />
+    </node>
+    <node concept="1TJgyj" id="Juyp1w3DPW" role="1TKVEi">
+      <property role="IQ2ns" value="855272232426839420" />
+      <property role="20lmBu" value="aggregation" />
+      <property role="20kJfa" value="right" />
+      <property role="20lbJX" value="1" />
+      <ref role="20lvS9" node="Juyp1w2LZ5" resolve="Expression" />
+    </node>
+    <node concept="PrWs8" id="Juyp1w3DPQ" role="PzmwI">
+      <ref role="PrY4T" node="Juyp1w2LZ5" resolve="Expression" />
+    </node>
+  </node>
+  <node concept="1TIwiD" id="Juyp1w4oKW">
+    <property role="EcuMT" value="855272232427031612" />
+    <property role="TrG5h" value="PlusExpression" />
+    <property role="34LRSv" value="+" />
+    <property role="3GE5qa" value="expression" />
+    <ref role="1TJDcQ" node="Juyp1w3DPP" resolve="BinaryExpression" />
+  </node>
+  <node concept="1TIwiD" id="Juyp1w4oLE">
+    <property role="EcuMT" value="855272232427031658" />
+    <property role="3GE5qa" value="expression" />
+    <property role="TrG5h" value="MinusExpression" />
+    <property role="34LRSv" value="-" />
+    <ref role="1TJDcQ" node="Juyp1w3DPP" resolve="BinaryExpression" />
+  </node>
+  <node concept="1TIwiD" id="Juyp1w4oUO">
+    <property role="EcuMT" value="855272232427032244" />
+    <property role="3GE5qa" value="expression" />
+    <property role="TrG5h" value="MulExpression" />
+    <property role="34LRSv" value="*" />
+    <ref role="1TJDcQ" node="Juyp1w3DPP" resolve="BinaryExpression" />
+  </node>
+  <node concept="1TIwiD" id="Juyp1w4pia">
+    <property role="EcuMT" value="855272232427033738" />
+    <property role="3GE5qa" value="expression" />
+    <property role="TrG5h" value="DivExpression" />
+    <property role="34LRSv" value="/" />
+    <ref role="1TJDcQ" node="Juyp1w3DPP" resolve="BinaryExpression" />
+  </node>
+  <node concept="1TIwiD" id="Juyp1w4RIQ">
+    <property role="EcuMT" value="855272232427158454" />
+    <property role="3GE5qa" value="expression" />
+    <property role="TrG5h" value="ParensExpression" />
+    <property role="34LRSv" value="(" />
+    <ref role="1TJDcQ" to="tpck:gw2VY9q" resolve="BaseConcept" />
+    <node concept="1TJgyj" id="Juyp1w4RIU" role="1TKVEi">
+      <property role="IQ2ns" value="855272232427158458" />
+      <property role="20lmBu" value="aggregation" />
+      <property role="20kJfa" value="expression" />
+      <property role="20lbJX" value="1" />
+      <ref role="20lvS9" node="Juyp1w2LZ5" resolve="Expression" />
+    </node>
+    <node concept="PrWs8" id="Juyp1w4RIR" role="PzmwI">
+      <ref role="PrY4T" node="Juyp1w2LZ5" resolve="Expression" />
+    </node>
+  </node>
+</model>
+

--- a/mps-workshop-2-itemis/languages/mps.workshop.lang/models/typesystem.mps
+++ b/mps-workshop-2-itemis/languages/mps.workshop.lang/models/typesystem.mps
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:eb9e8c55-3138-4aae-bda8-09d14989d4d3(mps.workshop.lang.typesystem)">
+  <persistence version="9" />
+  <languages>
+    <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="1" />
+    <devkit ref="00000000-0000-4000-0000-1de82b3a4936(jetbrains.mps.devkit.aspect.typesystem)" />
+  </languages>
+  <imports>
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
+    <import index="85g0" ref="r:3255fe94-9102-4828-b2d9-432a6ecad106(mps.workshop.lang.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+    </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
+        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
+      </concept>
+      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
+        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
+      </concept>
+    </language>
+    <language id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem">
+      <concept id="1185788614172" name="jetbrains.mps.lang.typesystem.structure.NormalTypeClause" flags="ng" index="mw_s8">
+        <child id="1185788644032" name="normalType" index="mwGJk" />
+      </concept>
+      <concept id="1195213580585" name="jetbrains.mps.lang.typesystem.structure.AbstractCheckingRule" flags="ig" index="18hYwZ">
+        <child id="1195213635060" name="body" index="18ibNy" />
+      </concept>
+      <concept id="1174642788531" name="jetbrains.mps.lang.typesystem.structure.ConceptReference" flags="ig" index="1YaCAy">
+        <reference id="1174642800329" name="concept" index="1YaFvo" />
+      </concept>
+      <concept id="1174643105530" name="jetbrains.mps.lang.typesystem.structure.InferenceRule" flags="ig" index="1YbPZF" />
+      <concept id="1174648085619" name="jetbrains.mps.lang.typesystem.structure.AbstractRule" flags="ng" index="1YuPPy">
+        <child id="1174648101952" name="applicableNode" index="1YuTPh" />
+      </concept>
+      <concept id="1174650418652" name="jetbrains.mps.lang.typesystem.structure.ApplicableNodeReference" flags="nn" index="1YBJjd">
+        <reference id="1174650432090" name="applicableNode" index="1YBMHb" />
+      </concept>
+      <concept id="1174657487114" name="jetbrains.mps.lang.typesystem.structure.TypeOfExpression" flags="nn" index="1Z2H0r">
+        <child id="1174657509053" name="term" index="1Z2MuG" />
+      </concept>
+      <concept id="1174658326157" name="jetbrains.mps.lang.typesystem.structure.CreateEquationStatement" flags="nn" index="1Z5TYs" />
+      <concept id="1174660718586" name="jetbrains.mps.lang.typesystem.structure.AbstractEquationStatement" flags="nn" index="1Zf1VF">
+        <child id="1174660783413" name="leftExpression" index="1ZfhK$" />
+        <child id="1174660783414" name="rightExpression" index="1ZfhKB" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1YbPZF" id="Juyp1w2X0j">
+    <property role="TrG5h" value="typeof_NumberLiteral" />
+    <property role="3GE5qa" value="expression" />
+    <node concept="3clFbS" id="Juyp1w2X0k" role="18ibNy">
+      <node concept="1Z5TYs" id="Juyp1w2Xdx" role="3cqZAp">
+        <node concept="mw_s8" id="Juyp1w2XdX" role="1ZfhKB">
+          <node concept="2pJPEk" id="Juyp1w2XdT" role="mwGJk">
+            <node concept="2pJPED" id="Juyp1w2Xj8" role="2pJPEn">
+              <ref role="2pJxaS" to="tpee:f_0OyhT" resolve="IntegerType" />
+            </node>
+          </node>
+        </node>
+        <node concept="mw_s8" id="Juyp1w2Xd$" role="1ZfhK$">
+          <node concept="1Z2H0r" id="Juyp1w2X0z" role="mwGJk">
+            <node concept="1YBJjd" id="Juyp1w2X0S" role="1Z2MuG">
+              <ref role="1YBMHb" node="Juyp1w2X0m" resolve="literal" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1YaCAy" id="Juyp1w2X0m" role="1YuTPh">
+      <property role="TrG5h" value="literal" />
+      <ref role="1YaFvo" to="85g0:Juyp1w2Ti3" resolve="NumberLiteral" />
+    </node>
+  </node>
+</model>
+

--- a/mps-workshop-2-itemis/languages/mps.workshop.lang/mps.workshop.lang.mpl
+++ b/mps-workshop-2-itemis/languages/mps.workshop.lang/mps.workshop.lang.mpl
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<language namespace="mps.workshop.lang" uuid="c9c683f9-1916-4ea4-bc6e-ec5b2a10659d" languageVersion="0" moduleVersion="0">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <accessoryModels />
+  <generators>
+    <generator alias="main" namespace="mps.workshop.lang#855272232426598083" uuid="3039c80b-2c0a-4d15-8de1-b9c7ce879b62" reflective-queries="true">
+      <models>
+        <modelRoot contentPath="${module}/generator/template" type="default">
+          <sourceRoot location="." />
+        </modelRoot>
+      </models>
+      <external-templates />
+      <dependencies>
+        <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
+      </dependencies>
+      <languageVersions>
+        <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="5" />
+        <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+        <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="0" />
+        <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+        <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+        <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+        <language slang="l:63650c59-16c8-498a-99c8-005c7ee9515d:jetbrains.mps.lang.access" version="0" />
+        <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="1" />
+        <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="0" />
+        <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="0" />
+        <language slang="l:289fcc83-6543-41e8-a5ca-768235715ce4:jetbrains.mps.lang.generator.generationParameters" version="0" />
+        <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="0" />
+        <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
+        <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="8" />
+        <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+        <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+      </languageVersions>
+      <dependencyVersions>
+        <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+        <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+        <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+        <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+        <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+        <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+        <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
+        <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
+        <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+        <module reference="c9c683f9-1916-4ea4-bc6e-ec5b2a10659d(mps.workshop.lang)" version="0" />
+        <module reference="3039c80b-2c0a-4d15-8de1-b9c7ce879b62(mps.workshop.lang#855272232426598083)" version="0" />
+        <module reference="e456fa2c-72f7-4cd4-a691-9b5511b7df4d(mps.workshop.runtime)" version="0" />
+      </dependencyVersions>
+      <mapping-priorities />
+    </generator>
+  </generators>
+  <sourcePath />
+  <dependencies>
+    <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
+    <dependency reexport="false">85da2157-b28c-4c6c-ac6d-66f42719ba01(mps.workshop.interpreter)</dependency>
+    <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:9d69e719-78c8-4286-90db-fb19c107d049:com.mbeddr.mpsutil.grammarcells" version="0" />
+    <language slang="l:b4f35ed8-45af-4efa-abe4-00ac26956e69:com.mbeddr.mpsutil.grammarcells.runtimelang" version="0" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="5" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="0" />
+    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:c7d5b9dd-a05f-4be2-bc73-f2e16994cc67:jetbrains.mps.baseLanguage.lightweightdsl" version="1" />
+    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+    <language slang="l:daafa647-f1f7-4b0b-b096-69cd7c8408c0:jetbrains.mps.baseLanguage.regexp" version="0" />
+    <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+    <language slang="l:df345b11-b8c7-4213-ac66-48d2a9b75d88:jetbrains.mps.baseLanguageInternal" version="0" />
+    <language slang="l:aee9cad2-acd4-4608-aef2-0004f6a1cdbd:jetbrains.mps.lang.actions" version="4" />
+    <language slang="l:af65afd8-f0dd-4942-87d9-63a55f2a9db1:jetbrains.mps.lang.behavior" version="1" />
+    <language slang="l:fe9d76d7-5809-45c9-ae28-a40915b4d6ff:jetbrains.mps.lang.checkedName" version="0" />
+    <language slang="l:3f4bc5f5-c6c1-4a28-8b10-c83066ffa4a1:jetbrains.mps.lang.constraints" version="4" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="1" />
+    <language slang="l:7fa12e9c-b949-4976-b4fa-19accbc320b4:jetbrains.mps.lang.dataFlow" version="1" />
+    <language slang="l:f4ad079d-bc71-4ffb-9600-9328705cf998:jetbrains.mps.lang.descriptor" version="0" />
+    <language slang="l:18bc6592-03a6-4e29-a83a-7ff23bde13ba:jetbrains.mps.lang.editor" version="11" />
+    <language slang="l:64d34fcd-ad02-4e73-aff8-a581124c2e30:jetbrains.mps.lang.findUsages" version="0" />
+    <language slang="l:b401a680-8325-4110-8fd3-84331ff25bef:jetbrains.mps.lang.generator" version="0" />
+    <language slang="l:d7706f63-9be2-479c-a3da-ae92af1e64d5:jetbrains.mps.lang.generator.generationContext" version="0" />
+    <language slang="l:d7a92d38-f7db-40d0-8431-763b0c3c9f20:jetbrains.mps.lang.intentions" version="0" />
+    <language slang="l:d4615e3b-d671-4ba9-af01-2b78369b0ba7:jetbrains.mps.lang.pattern" version="1" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="0" />
+    <language slang="l:3ecd7c84-cde3-45de-886c-135ecc69b742:jetbrains.mps.lang.refactoring" version="0" />
+    <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
+    <language slang="l:0eddeefa-c2d6-4437-bc2c-de50fd4ce470:jetbrains.mps.lang.script" version="0" />
+    <language slang="l:13744753-c81f-424a-9c1b-cf8943bf4e86:jetbrains.mps.lang.sharedConcepts" version="0" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="8" />
+    <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="6" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+    <language slang="l:b83431fe-5c8f-40bc-8a36-65e25f4dd253:jetbrains.mps.lang.textGen" version="1" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+    <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="1" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
+    <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
+    <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
+    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+    <module reference="85da2157-b28c-4c6c-ac6d-66f42719ba01(mps.workshop.interpreter)" version="0" />
+    <module reference="c9c683f9-1916-4ea4-bc6e-ec5b2a10659d(mps.workshop.lang)" version="0" />
+  </dependencyVersions>
+  <runtime>
+    <dependency reexport="false">e456fa2c-72f7-4cd4-a691-9b5511b7df4d(mps.workshop.runtime)</dependency>
+  </runtime>
+  <extendedLanguages />
+</language>
+

--- a/mps-workshop-2-itemis/solutions/mps.workshop.executor/models/plugin.mps
+++ b/mps-workshop-2-itemis/solutions/mps.workshop.executor/models/plugin.mps
@@ -1,0 +1,1360 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:afac2e70-1116-40ab-82f2-79bcf372fe21(mps.workshop.executor.plugin)">
+  <persistence version="9" />
+  <languages>
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="8" />
+    <use id="22e72e4c-0f69-46ce-8403-6750153aa615" name="jetbrains.mps.execution.configurations" version="1" />
+    <use id="982eb8df-2c96-4bd7-9963-11712ea622e5" name="jetbrains.mps.lang.resources" version="2" />
+    <use id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections" version="0" />
+    <use id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <use id="756e911c-3f1f-4a48-bdf5-a2ceb91b723c" name="jetbrains.mps.execution.settings" version="0" />
+    <use id="f3347d8a-0e79-4f35-8ac9-1574f25c986f" name="jetbrains.mps.execution.commands" version="0" />
+    <use id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples" version="0" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="5" />
+    <use id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures" version="0" />
+    <use id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone" version="0" />
+    <use id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access" version="0" />
+    <use id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots" version="0" />
+    <use id="fbc14279-5e2a-4c87-a5d1-5f7061e6c456" name="jetbrains.mps.debugger.api.lang" version="1" />
+  </languages>
+  <imports>
+    <import index="dxuu" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:javax.swing(JDK/)" />
+    <import index="v23q" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.openapi(MPS.IDEA/)" />
+    <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" />
+    <import index="z1c3" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project(MPS.Core/)" />
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
+    <import index="xk9i" ref="r:49e49752-a85e-4d81-811e-1dc850a8e4cd(jetbrains.mps.execution.lib.ui)" />
+    <import index="w1kc" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel(MPS.Core/)" />
+    <import index="go48" ref="r:fc6b4266-fe93-4e02-bc36-aebff4c903c3(jetbrains.mps.baseLanguage.execution.api)" />
+    <import index="tprs" ref="r:00000000-0000-4000-0000-011c895904a4(jetbrains.mps.ide.actions)" />
+    <import index="z60i" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.awt(JDK/)" />
+    <import index="awpe" ref="r:5a505993-793e-4b2d-84cf-271f9dde39b3(jetbrains.mps.execution.lib)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="eva" ref="r:a1b1112d-dd34-4046-a6a3-811fd290d232(jetbrains.mps.execution.configurations.pluginSolution.plugin)" />
+    <import index="cjdg" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.execution.ui(MPS.IDEA/)" />
+    <import index="feyl" ref="498d89d2-c2e9-11e2-ad49-6cf049e62fe5/java:com.intellij.execution.actions(MPS.IDEA/)" />
+    <import index="alof" ref="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61/java:jetbrains.mps.ide.project(MPS.Platform/)" />
+    <import index="33ny" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util(JDK/)" />
+    <import index="irxm" ref="86441d7a-e194-42da-81a5-2161ec62a379/java:jetbrains.mps.plugins.runconfigs(MPS.Workbench/)" />
+    <import index="85g0" ref="r:3255fe94-9102-4828-b2d9-432a6ecad106(mps.workshop.lang.structure)" />
+    <import index="b0pz" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project.facets(MPS.Core/)" />
+    <import index="w0gx" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.project.structure.modules(MPS.Core/)" />
+  </imports>
+  <registry>
+    <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
+      <concept id="1239531918181" name="jetbrains.mps.baseLanguage.tuples.structure.NamedTupleType" flags="in" index="2pR195" />
+      <concept id="1239559992092" name="jetbrains.mps.baseLanguage.tuples.structure.NamedTupleLiteral" flags="nn" index="2ry78W">
+        <reference id="1239560008022" name="tupleDeclaration" index="2ryb1Q" />
+        <child id="1239560910577" name="componentRef" index="2r_Bvh" />
+      </concept>
+      <concept id="1239560581441" name="jetbrains.mps.baseLanguage.tuples.structure.NamedTupleComponentReference" flags="ng" index="2r$n1x">
+        <reference id="1239560595302" name="componentDeclaration" index="2r$qp6" />
+        <child id="1239560837729" name="value" index="2r_lH1" />
+      </concept>
+      <concept id="1239576519914" name="jetbrains.mps.baseLanguage.tuples.structure.NamedTupleComponentAccessOperation" flags="nn" index="2sxana">
+        <reference id="1239576542472" name="component" index="2sxfKC" />
+      </concept>
+    </language>
+    <language id="982eb8df-2c96-4bd7-9963-11712ea622e5" name="jetbrains.mps.lang.resources">
+      <concept id="8974276187400029883" name="jetbrains.mps.lang.resources.structure.FileIcon" flags="ng" index="1QGGSu" />
+    </language>
+    <language id="f3347d8a-0e79-4f35-8ac9-1574f25c986f" name="jetbrains.mps.execution.commands">
+      <concept id="856705193941281780" name="jetbrains.mps.execution.commands.structure.CommandBuilderExpression" flags="nn" index="2LYoGx">
+        <reference id="6129022259108621329" name="commandPart" index="3rFKlk" />
+        <child id="856705193941281781" name="argument" index="2LYoGw" />
+      </concept>
+      <concept id="856705193941281790" name="jetbrains.mps.execution.commands.structure.ReportExecutionError" flags="nn" index="2LYoGF" />
+      <concept id="856705193941281764" name="jetbrains.mps.execution.commands.structure.CommandParameterAssignment" flags="ng" index="2LYoGL">
+        <reference id="856705193941281765" name="parameterDeclaration" index="2LYoGK" />
+        <child id="856705193941281766" name="value" index="2LYoGN" />
+      </concept>
+      <concept id="856705193941281792" name="jetbrains.mps.execution.commands.structure.ReportErrorStatement" flags="nn" index="2LYoNl">
+        <child id="856705193941281795" name="message" index="2LYoNm" />
+      </concept>
+    </language>
+    <language id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone">
+      <concept id="7520713872864775836" name="jetbrains.mps.lang.plugin.standalone.structure.StandalonePluginDescriptor" flags="ng" index="2DaZZR" />
+    </language>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="ng" index="2tJIrI" />
+      <concept id="1188207840427" name="jetbrains.mps.baseLanguage.structure.AnnotationInstance" flags="nn" index="2AHcQZ">
+        <reference id="1188208074048" name="annotation" index="2AI5Lk" />
+      </concept>
+      <concept id="1188208481402" name="jetbrains.mps.baseLanguage.structure.HasAnnotation" flags="ng" index="2AJDlI">
+        <child id="1188208488637" name="annotation" index="2AJF6D" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1137021947720" name="jetbrains.mps.baseLanguage.structure.ConceptFunction" flags="in" index="2VMwT0">
+        <child id="1137022507850" name="body" index="2VODD2" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
+        <child id="1081256993305" name="classType" index="2ZW6by" />
+        <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
+      </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534644030" name="jetbrains.mps.baseLanguage.structure.BooleanType" flags="in" index="10P_77" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <property id="1176718929932" name="isFinal" index="3TUv4t" />
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <property id="4276006055363816570" name="isSynchronized" index="od$2w" />
+        <property id="1181808852946" name="isFinal" index="DiZV1" />
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068580123137" name="jetbrains.mps.baseLanguage.structure.BooleanConstant" flags="nn" index="3clFbT">
+        <property id="1068580123138" name="value" index="3clFbU" />
+      </concept>
+      <concept id="1068581242875" name="jetbrains.mps.baseLanguage.structure.PlusExpression" flags="nn" index="3cpWs3" />
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk">
+        <child id="1212687122400" name="typeParameter" index="1pMfVU" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="7812454656619025416" name="jetbrains.mps.baseLanguage.structure.MethodDeclaration" flags="ng" index="1rXfSm">
+        <property id="8355037393041754995" name="isNative" index="2aFKle" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+        <child id="1109201940907" name="parameter" index="11_B2D" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1116615150612" name="jetbrains.mps.baseLanguage.structure.ClassifierClassExpression" flags="nn" index="3VsKOn">
+        <reference id="1116615189566" name="classifier" index="3VsUkX" />
+      </concept>
+    </language>
+    <language id="63650c59-16c8-498a-99c8-005c7ee9515d" name="jetbrains.mps.lang.access">
+      <concept id="8974276187400348173" name="jetbrains.mps.lang.access.structure.CommandClosureLiteral" flags="nn" index="1QHqEC" />
+      <concept id="8974276187400348170" name="jetbrains.mps.lang.access.structure.BaseExecuteCommandStatement" flags="nn" index="1QHqEJ">
+        <child id="1423104411234567454" name="repo" index="ukAjM" />
+        <child id="8974276187400348171" name="commandClosureLiteral" index="1QHqEI" />
+      </concept>
+      <concept id="8974276187400348181" name="jetbrains.mps.lang.access.structure.ExecuteLightweightCommandStatement" flags="nn" index="1QHqEK" />
+    </language>
+    <language id="774bf8a0-62e5-41e1-af63-f4812e60e48b" name="jetbrains.mps.baseLanguage.checkedDots">
+      <concept id="4079382982702596667" name="jetbrains.mps.baseLanguage.checkedDots.structure.CheckedDotExpression" flags="nn" index="2EnYce" />
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569906740" name="parameter" index="1bW2Oz" />
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
+    </language>
+    <language id="22e72e4c-0f69-46ce-8403-6750153aa615" name="jetbrains.mps.execution.configurations">
+      <concept id="7684700299064179245" name="jetbrains.mps.execution.configurations.structure.Project_Parameter" flags="nn" index="21ER0p" />
+      <concept id="1594211126127774346" name="jetbrains.mps.execution.configurations.structure.ConsoleCreator" flags="nn" index="2bNoKo">
+        <child id="1594211126127774926" name="viewer" index="2bNoDs" />
+        <child id="1594211126127774925" name="project" index="2bNoDv" />
+      </concept>
+      <concept id="1594211126127733907" name="jetbrains.mps.execution.configurations.structure.ConsoleType" flags="in" index="2bNAC1" />
+      <concept id="4805365031744813267" name="jetbrains.mps.execution.configurations.structure.Configuration_Parameter" flags="ng" index="nyUVq" />
+      <concept id="4805365031745089663" name="jetbrains.mps.execution.configurations.structure.ContextConfiguration_Parameter" flags="ng" index="nzYpQ" />
+      <concept id="7301162575811126385" name="jetbrains.mps.execution.configurations.structure.NodeSource" flags="ng" index="2nMXjs">
+        <reference id="7301162575811126914" name="concept" index="2nMXoJ" />
+      </concept>
+      <concept id="4366236229294149030" name="jetbrains.mps.execution.configurations.structure.RunConfigurationProducerPart" flags="ng" index="2w4N4h">
+        <child id="7301162575811113551" name="source" index="2nMwby" />
+        <child id="3642991921657904774" name="create" index="30xZXv" />
+        <child id="6232089240471267799" name="isConfigurationFromContext" index="1WFzRM" />
+      </concept>
+      <concept id="4366236229294149059" name="jetbrains.mps.execution.configurations.structure.Create_ConceptFunction" flags="in" index="2w4N5O" />
+      <concept id="4366236229294105349" name="jetbrains.mps.execution.configurations.structure.RunConfigurationProducer" flags="ng" index="2w4XYM">
+        <child id="4366236229294149036" name="produce" index="2w4N4r" />
+        <child id="4366236229294139631" name="configuration" index="2w4Pho" />
+      </concept>
+      <concept id="946964771156870353" name="jetbrains.mps.execution.configurations.structure.StartProcessHandlerStatement" flags="nn" index="yIgYw">
+        <child id="1594211126127621024" name="tool" index="2bO3kM" />
+      </concept>
+      <concept id="6550182048787537880" name="jetbrains.mps.execution.configurations.structure.BeforeTaskCall" flags="ng" index="yYvg6">
+        <reference id="6550182048787537881" name="beforeTask" index="yYvg7" />
+        <child id="5475888311765521408" name="parameter" index="1ZwhtC" />
+      </concept>
+      <concept id="7806358006983614956" name="jetbrains.mps.execution.configurations.structure.RunConfigurationExecutor" flags="ng" index="RBi3j">
+        <property id="6226796386650281949" name="canDebug" index="3c$X6f" />
+      </concept>
+      <concept id="7806358006983738927" name="jetbrains.mps.execution.configurations.structure.ConfigurationFromExecutorReference" flags="nn" index="RBKsg" />
+      <concept id="3642991921658122718" name="jetbrains.mps.execution.configurations.structure.RunConfigurationCreator" flags="nn" index="30w_07">
+        <reference id="3642991921658122719" name="configuration" index="30w_06" />
+        <child id="529406319400385974" name="configurationName" index="uV2A8" />
+      </concept>
+      <concept id="3642991921657904775" name="jetbrains.mps.execution.configurations.structure.Source_ConceptFunctionParameter" flags="nn" index="30xZXu" />
+      <concept id="5453800039284219178" name="jetbrains.mps.execution.configurations.structure.GetProjectOperation" flags="nn" index="3a8Xsn" />
+      <concept id="2401501559171392633" name="jetbrains.mps.execution.configurations.structure.AbstractRunConfigurationExecutor" flags="ng" index="3wDJM8">
+        <property id="5925077313451868299" name="canRun" index="35f5FB" />
+        <property id="1931462339887551644" name="configurationName" index="3gLNDv" />
+        <child id="6550182048787537895" name="beforeTask" index="yYvgT" />
+        <child id="7945003362267213473" name="execute" index="35uJNn" />
+      </concept>
+      <concept id="2401501559171345993" name="jetbrains.mps.execution.configurations.structure.RunConfiguration" flags="ng" index="3wDVqS">
+        <reference id="2401501559171353314" name="configurationKind" index="3wDP8j" />
+        <child id="4763274727405873310" name="icon" index="3GxumY" />
+      </concept>
+      <concept id="2401501559171345994" name="jetbrains.mps.execution.configurations.structure.RunConfigurationKind" flags="ng" index="3wDVqV">
+        <child id="7966814097310618131" name="icon" index="1bitO_" />
+      </concept>
+      <concept id="5263715862011154550" name="jetbrains.mps.execution.configurations.structure.IsConfigurationFromContext_ConceptFunction" flags="ig" index="1wNYB6" />
+      <concept id="6139196002333163564" name="jetbrains.mps.execution.configurations.structure.ExecuteConfiguration_Function" flags="in" index="3CCWSg" />
+    </language>
+    <language id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers">
+      <concept id="1205752633985" name="jetbrains.mps.baseLanguage.classifiers.structure.ThisClassifierExpression" flags="nn" index="2WthIp" />
+      <concept id="1205756064662" name="jetbrains.mps.baseLanguage.classifiers.structure.IMemberOperation" flags="ng" index="2WEnae">
+        <reference id="1205756909548" name="member" index="2WH_rO" />
+      </concept>
+      <concept id="1205769149993" name="jetbrains.mps.baseLanguage.classifiers.structure.DefaultClassifierMethodCallOperation" flags="nn" index="2XshWL">
+        <child id="1205770614681" name="actualArgument" index="2XxRq1" />
+      </concept>
+    </language>
+    <language id="756e911c-3f1f-4a48-bdf5-a2ceb91b723c" name="jetbrains.mps.execution.settings">
+      <concept id="946964771156067216" name="jetbrains.mps.execution.settings.structure.Configuration_Parameter" flags="nn" index="yHkzx" />
+      <concept id="946964771156066611" name="jetbrains.mps.execution.settings.structure.EditorPropertyReference" flags="nn" index="yHkD2" />
+      <concept id="946964771156066610" name="jetbrains.mps.execution.settings.structure.EditorPropertyDeclaration" flags="ng" index="yHkD3" />
+      <concept id="946964771156066614" name="jetbrains.mps.execution.settings.structure.ResetFrom_Function" flags="ig" index="yHkD7" />
+      <concept id="946964771156066621" name="jetbrains.mps.execution.settings.structure.SettingsEditor" flags="ng" index="yHkDc">
+        <child id="946964771156066625" name="dispose" index="yHkCK" />
+        <child id="946964771156066624" name="resetFrom" index="yHkCL" />
+        <child id="946964771156066626" name="propertyDeclaration" index="yHkCN" />
+        <child id="946964771156066623" name="applyTo" index="yHkDe" />
+        <child id="946964771156066622" name="createEditor" index="yHkDf" />
+      </concept>
+      <concept id="946964771156066594" name="jetbrains.mps.execution.settings.structure.IPersistentPropertyHolder" flags="ng" index="yHkDj">
+        <child id="946964771156066595" name="persistentProperty" index="yHkDi" />
+      </concept>
+      <concept id="946964771156066597" name="jetbrains.mps.execution.settings.structure.CheckProperties_Function" flags="ig" index="yHkDk" />
+      <concept id="946964771156066601" name="jetbrains.mps.execution.settings.structure.ApplyTo_Function" flags="ig" index="yHkDo" />
+      <concept id="946964771156066606" name="jetbrains.mps.execution.settings.structure.EditorOperationCall" flags="nn" index="yHkDv">
+        <reference id="946964771156066609" name="editorOperationDeclaration" index="yHkD0" />
+        <child id="946964771156066607" name="arguments" index="yHkDu" />
+      </concept>
+      <concept id="946964771156066582" name="jetbrains.mps.execution.settings.structure.PersistentConfigurationTemplateInitializer" flags="nn" index="yHkDB">
+        <reference id="946964771156066583" name="template" index="yHkDA" />
+        <child id="946964771156066584" name="parameter" index="yHkDD" />
+      </concept>
+      <concept id="946964771156066585" name="jetbrains.mps.execution.settings.structure.PersistentPropertyDeclaration" flags="ng" index="yHkDC" />
+      <concept id="946964771156066588" name="jetbrains.mps.execution.settings.structure.EditorExpression" flags="nn" index="yHkDH">
+        <reference id="946964771156066589" name="persistentPropertyDeclaration" index="yHkDG" />
+      </concept>
+      <concept id="946964771156066591" name="jetbrains.mps.execution.settings.structure.CheckProperitesOperation" flags="nn" index="yHkDI" />
+      <concept id="946964771156066566" name="jetbrains.mps.execution.settings.structure.CreateEditor_Function" flags="ig" index="yHkDR" />
+      <concept id="946964771156066571" name="jetbrains.mps.execution.settings.structure.Dispose_Function" flags="ig" index="yHkDU" />
+      <concept id="946964771156066574" name="jetbrains.mps.execution.settings.structure.PersistentPropertyReferenceOperation" flags="nn" index="yHkDZ">
+        <reference id="946964771156066575" name="variableDeclaration" index="yHkDY" />
+      </concept>
+      <concept id="946964771156066336" name="jetbrains.mps.execution.settings.structure.PersistentConfiguration" flags="ng" index="yHkHh">
+        <child id="946964771156066337" name="editor" index="yHkHg" />
+        <child id="946964771156066339" name="methods" index="yHkHi" />
+        <child id="946964771156066338" name="checkProperties" index="yHkHj" />
+      </concept>
+      <concept id="946964771156066331" name="jetbrains.mps.execution.settings.structure.PersistentConfigurationMethod" flags="ng" index="yHkHE" />
+      <concept id="946964771156066332" name="jetbrains.mps.execution.settings.structure.PersistentConfigurationType" flags="in" index="yHkHH">
+        <reference id="946964771156066333" name="persistentConfiguration" index="yHkHG" />
+      </concept>
+      <concept id="946964771156066557" name="jetbrains.mps.execution.settings.structure.TemplatePersistentConfigurationType" flags="in" index="yHkIc" />
+      <concept id="946964771156905617" name="jetbrains.mps.execution.settings.structure.PersistentConfigurationAssistent" flags="ng" index="yIonw">
+        <reference id="946964771156905618" name="configuration" index="yIonz" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1145404486709" name="jetbrains.mps.lang.smodel.structure.SemanticDowncastExpression" flags="nn" index="2JrnkZ">
+        <child id="1145404616321" name="leftExpression" index="2JrQYb" />
+      </concept>
+      <concept id="2644386474300074836" name="jetbrains.mps.lang.smodel.structure.ConceptIdRefExpression" flags="nn" index="35c_gC">
+        <reference id="2644386474300074837" name="conceptDeclaration" index="35c_gD" />
+      </concept>
+      <concept id="4040588429969021681" name="jetbrains.mps.lang.smodel.structure.ModuleReferenceExpression" flags="nn" index="3rM5sP">
+        <property id="4040588429969021683" name="moduleId" index="3rM5sR" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1133920641626" name="jetbrains.mps.lang.core.structure.BaseConcept" flags="ng" index="2VYdi">
+        <property id="1193676396447" name="virtualPackage" index="3GE5qa" />
+        <child id="5169995583184591170" name="smodelAttribute" index="lGtFl" />
+      </concept>
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+      <concept id="4222318806802425298" name="jetbrains.mps.lang.core.structure.SuppressErrorsAnnotation" flags="ng" index="15s5l7" />
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1151688443754" name="jetbrains.mps.baseLanguage.collections.structure.ListType" flags="in" index="_YKpA">
+        <child id="1151688676805" name="elementType" index="_ZDj9" />
+      </concept>
+      <concept id="1151689724996" name="jetbrains.mps.baseLanguage.collections.structure.SequenceType" flags="in" index="A3Dl8">
+        <child id="1151689745422" name="elementType" index="A3Ik2" />
+      </concept>
+      <concept id="1151702311717" name="jetbrains.mps.baseLanguage.collections.structure.ToListOperation" flags="nn" index="ANE8D" />
+      <concept id="1235573135402" name="jetbrains.mps.baseLanguage.collections.structure.SingletonSequenceCreator" flags="nn" index="2HTt$P">
+        <child id="1235573175711" name="elementType" index="2HTBi0" />
+        <child id="1235573187520" name="singletonValue" index="2HTEbv" />
+      </concept>
+      <concept id="1237721394592" name="jetbrains.mps.baseLanguage.collections.structure.AbstractContainerCreator" flags="nn" index="HWqM0">
+        <child id="1237721435808" name="initValue" index="HW$Y0" />
+        <child id="1237721435807" name="elementType" index="HW$YZ" />
+      </concept>
+      <concept id="1160600644654" name="jetbrains.mps.baseLanguage.collections.structure.ListCreatorWithInit" flags="nn" index="Tc6Ow" />
+      <concept id="1184963466173" name="jetbrains.mps.baseLanguage.collections.structure.ToArrayOperation" flags="nn" index="3_kTaI" />
+    </language>
+  </registry>
+  <node concept="3wDVqS" id="5gyVhZ17Jj8">
+    <property role="TrG5h" value="Functional" />
+    <property role="3GE5qa" value="" />
+    <ref role="3wDP8j" node="5gyVhZ17Jm9" resolve="Functional Application" />
+    <node concept="yHkHE" id="5aSLaYRTp9U" role="yHkHi">
+      <property role="TrG5h" value="isFromContext" />
+      <node concept="10P_77" id="5aSLaYRTpn_" role="3clF45" />
+      <node concept="3clFbS" id="5aSLaYRTp9W" role="3clF47">
+        <node concept="3clFbJ" id="5aSLaYRTpwP" role="3cqZAp">
+          <node concept="2ZW3vV" id="5aSLaYRTpwQ" role="3clFbw">
+            <node concept="3uibUv" id="5aSLaYRTpwR" role="2ZW6by">
+              <ref role="3uigEE" to="irxm:~MPSPsiElement" resolve="MPSPsiElement" />
+            </node>
+            <node concept="2OqwBi" id="5aSLaYRTpwS" role="2ZW6bz">
+              <node concept="37vLTw" id="5aSLaYRTv3M" role="2Oq$k0">
+                <ref role="3cqZAo" node="5aSLaYRTpsc" resolve="context" />
+              </node>
+              <node concept="liA8E" id="5aSLaYRTpwU" role="2OqNvi">
+                <ref role="37wK5l" to="feyl:~ConfigurationContext.getPsiLocation():com.intellij.psi.PsiElement" resolve="getPsiLocation" />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="5aSLaYRTpwV" role="3clFbx">
+            <node concept="3cpWs8" id="5aSLaYRTpwW" role="3cqZAp">
+              <node concept="3cpWsn" id="5aSLaYRTpwX" role="3cpWs9">
+                <property role="TrG5h" value="mpsElement" />
+                <property role="3TUv4t" value="true" />
+                <node concept="3uibUv" id="5aSLaYRTpwY" role="1tU5fm">
+                  <ref role="3uigEE" to="irxm:~MPSPsiElement" resolve="MPSPsiElement" />
+                </node>
+                <node concept="10QFUN" id="5aSLaYRTpwZ" role="33vP2m">
+                  <node concept="3uibUv" id="5aSLaYRTpx0" role="10QFUM">
+                    <ref role="3uigEE" to="irxm:~MPSPsiElement" resolve="MPSPsiElement" />
+                  </node>
+                  <node concept="2OqwBi" id="5aSLaYRTpx1" role="10QFUP">
+                    <node concept="37vLTw" id="5aSLaYRTv4j" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5aSLaYRTpsc" resolve="context" />
+                    </node>
+                    <node concept="liA8E" id="5aSLaYRTpx3" role="2OqNvi">
+                      <ref role="37wK5l" to="feyl:~ConfigurationContext.getPsiLocation():com.intellij.psi.PsiElement" resolve="getPsiLocation" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="9iT$9ks8kK" role="3cqZAp">
+              <node concept="3clFbS" id="9iT$9ks8kM" role="3clFbx">
+                <node concept="3cpWs8" id="1hFhnCnyjHe" role="3cqZAp">
+                  <node concept="3cpWsn" id="1hFhnCnyjHf" role="3cpWs9">
+                    <property role="TrG5h" value="nodePointer" />
+                    <property role="3TUv4t" value="true" />
+                    <node concept="3uibUv" id="9iT$9kr9rm" role="1tU5fm">
+                      <ref role="3uigEE" to="mhbf:~SNodeReference" resolve="SNodeReference" />
+                    </node>
+                    <node concept="2OqwBi" id="1hFhnCnyjHg" role="33vP2m">
+                      <node concept="37vLTw" id="1hFhnCnyjHh" role="2Oq$k0">
+                        <ref role="3cqZAo" node="5aSLaYRTpwX" resolve="mpsElement" />
+                      </node>
+                      <node concept="liA8E" id="1hFhnCnyjHi" role="2OqNvi">
+                        <ref role="37wK5l" to="irxm:~MPSPsiElement.getUnresolvedItem(java.lang.Class):java.lang.Object" resolve="getUnresolvedItem" />
+                        <node concept="3VsKOn" id="1hFhnCnyjHj" role="37wK5m">
+                          <ref role="3VsUkX" to="mhbf:~SNodeReference" resolve="SNodeReference" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs8" id="9iT$9ks1Lg" role="3cqZAp">
+                  <node concept="3cpWsn" id="9iT$9ks1Lh" role="3cpWs9">
+                    <property role="TrG5h" value="repository" />
+                    <property role="3TUv4t" value="true" />
+                    <node concept="3uibUv" id="9iT$9ks1Lf" role="1tU5fm">
+                      <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+                    </node>
+                    <node concept="2OqwBi" id="9iT$9ks1Li" role="33vP2m">
+                      <node concept="2OqwBi" id="9iT$9ks1Lj" role="2Oq$k0">
+                        <node concept="37vLTw" id="9iT$9ks1Lk" role="2Oq$k0">
+                          <ref role="3cqZAo" node="5aSLaYRTpwX" resolve="mpsElement" />
+                        </node>
+                        <node concept="liA8E" id="9iT$9ks1Ll" role="2OqNvi">
+                          <ref role="37wK5l" to="irxm:~MPSPsiElement.getMPSProject():jetbrains.mps.project.MPSProject" resolve="getMPSProject" />
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="9iT$9ks1Lm" role="2OqNvi">
+                        <ref role="37wK5l" to="z1c3:~Project.getRepository():org.jetbrains.mps.openapi.module.SRepository" resolve="getRepository" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3cpWs6" id="1gY6kQfGpDI" role="3cqZAp">
+                  <node concept="2OqwBi" id="9iT$9krIXf" role="3cqZAk">
+                    <node concept="2ShNRf" id="9iT$9krfig" role="2Oq$k0">
+                      <node concept="1pGfFk" id="9iT$9krFJa" role="2ShVmc">
+                        <ref role="37wK5l" to="w1kc:~ModelAccessHelper.&lt;init&gt;(org.jetbrains.mps.openapi.module.SRepository)" resolve="ModelAccessHelper" />
+                        <node concept="37vLTw" id="9iT$9ks1Ln" role="37wK5m">
+                          <ref role="3cqZAo" node="9iT$9ks1Lh" resolve="repository" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="9iT$9krJrM" role="2OqNvi">
+                      <ref role="37wK5l" to="w1kc:~ModelAccessHelper.runReadAction(jetbrains.mps.util.Computable):java.lang.Object" resolve="runReadAction" />
+                      <node concept="1bVj0M" id="9iT$9krJvb" role="37wK5m">
+                        <node concept="3clFbS" id="9iT$9krJvc" role="1bW5cS">
+                          <node concept="3cpWs8" id="1gY6kQfGr4q" role="3cqZAp">
+                            <node concept="3cpWsn" id="1gY6kQfGr4t" role="3cpWs9">
+                              <property role="TrG5h" value="source" />
+                              <property role="3TUv4t" value="true" />
+                              <node concept="3Tqbb2" id="1gY6kQfGr4o" role="1tU5fm" />
+                              <node concept="2OqwBi" id="9iT$9ks1uN" role="33vP2m">
+                                <node concept="37vLTw" id="9iT$9krJ$K" role="2Oq$k0">
+                                  <ref role="3cqZAo" node="1hFhnCnyjHf" resolve="nodePointer" />
+                                </node>
+                                <node concept="liA8E" id="9iT$9ks1FF" role="2OqNvi">
+                                  <ref role="37wK5l" to="mhbf:~SNodeReference.resolve(org.jetbrains.mps.openapi.module.SRepository):org.jetbrains.mps.openapi.model.SNode" resolve="resolve" />
+                                  <node concept="37vLTw" id="9iT$9ks1Uo" role="37wK5m">
+                                    <ref role="3cqZAo" node="9iT$9ks1Lh" resolve="repository" />
+                                  </node>
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3cpWs6" id="1hFhnCnyjMs" role="3cqZAp">
+                            <node concept="2YIFZM" id="1hFhnCnyjO9" role="3cqZAk">
+                              <ref role="37wK5l" to="33ny:~Objects.equals(java.lang.Object,java.lang.Object):boolean" resolve="equals" />
+                              <ref role="1Pybhc" to="33ny:~Objects" resolve="Objects" />
+                              <node concept="2OqwBi" id="9iT$9kskWG" role="37wK5m">
+                                <node concept="2JrnkZ" id="9iT$9ksm2F" role="2Oq$k0">
+                                  <node concept="37vLTw" id="1gY6kQfGtap" role="2JrQYb">
+                                    <ref role="3cqZAo" node="1gY6kQfGr4t" resolve="source" />
+                                  </node>
+                                </node>
+                                <node concept="liA8E" id="9iT$9ksmq7" role="2OqNvi">
+                                  <ref role="37wK5l" to="mhbf:~SNode.getReference():org.jetbrains.mps.openapi.model.SNodeReference" resolve="getReference" />
+                                </node>
+                              </node>
+                              <node concept="2OqwBi" id="1hFhnCnykzN" role="37wK5m">
+                                <node concept="2OqwBi" id="1hFhnCnyjX3" role="2Oq$k0">
+                                  <node concept="2WthIp" id="1hFhnCnyjOw" role="2Oq$k0" />
+                                  <node concept="yHkDZ" id="1hFhnCnyk7r" role="2OqNvi">
+                                    <ref role="yHkDY" node="5gyVhZ17JkL" resolve="myNode" />
+                                  </node>
+                                </node>
+                                <node concept="2XshWL" id="1hFhnCnylqP" role="2OqNvi">
+                                  <ref role="2WH_rO" to="awpe:7byHRlLCxOy" resolve="getNode" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3y3z36" id="9iT$9ks9si" role="3clFbw">
+                <node concept="10Nm6u" id="9iT$9ks9st" role="3uHU7w" />
+                <node concept="37vLTw" id="9iT$9ks8m6" role="3uHU7B">
+                  <ref role="3cqZAo" node="5aSLaYRTpwX" resolve="mpsElement" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="5aSLaYRTpxK" role="3cqZAp">
+          <node concept="3clFbT" id="5aSLaYRTpxL" role="3cqZAk">
+            <property role="3clFbU" value="false" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="5aSLaYRTpkk" role="1B3o_S" />
+      <node concept="37vLTG" id="5aSLaYRTpsc" role="3clF46">
+        <property role="TrG5h" value="context" />
+        <property role="3TUv4t" value="true" />
+        <node concept="3uibUv" id="5aSLaYRTpsb" role="1tU5fm">
+          <ref role="3uigEE" to="feyl:~ConfigurationContext" resolve="ConfigurationContext" />
+        </node>
+        <node concept="2AHcQZ" id="5aSLaYRTpsg" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+    </node>
+    <node concept="yHkDc" id="5gyVhZ17Jj9" role="yHkHg">
+      <node concept="yHkD3" id="5gyVhZ17Jja" role="yHkCN">
+        <property role="TrG5h" value="myLabel" />
+        <node concept="3uibUv" id="5gyVhZ17Jjb" role="1tU5fm">
+          <ref role="3uigEE" to="dxuu:~JLabel" resolve="JLabel" />
+        </node>
+      </node>
+      <node concept="yHkDR" id="5gyVhZ17Jjc" role="yHkDf">
+        <node concept="3clFbS" id="5gyVhZ17Jjd" role="2VODD2">
+          <node concept="3clFbF" id="5gyVhZ17Jje" role="3cqZAp">
+            <node concept="37vLTI" id="5gyVhZ17Jjf" role="3clFbG">
+              <node concept="2ShNRf" id="5gyVhZ17Jjg" role="37vLTx">
+                <node concept="1pGfFk" id="5gyVhZ17Jjh" role="2ShVmc">
+                  <ref role="37wK5l" to="dxuu:~JLabel.&lt;init&gt;(java.lang.String)" resolve="JLabel" />
+                  <node concept="Xl_RD" id="5gyVhZ17Jji" role="37wK5m">
+                    <property role="Xl_RC" value="Select Worksheet:" />
+                  </node>
+                </node>
+              </node>
+              <node concept="yHkD2" id="5gyVhZ17Jjj" role="37vLTJ">
+                <ref role="3cqZAo" node="5gyVhZ17Jja" resolve="myLabel" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="5gyVhZ17Jjk" role="3cqZAp">
+            <node concept="3cpWsn" id="5gyVhZ17Jjl" role="3cpWs9">
+              <property role="TrG5h" value="nodeChooser" />
+              <node concept="3uibUv" id="7byHRlLCzr_" role="1tU5fm">
+                <ref role="3uigEE" to="xk9i:7byHRlLCxS0" resolve="NodeBySeveralConceptChooser" />
+              </node>
+              <node concept="2OqwBi" id="5gyVhZ17Jjn" role="33vP2m">
+                <node concept="yHkDH" id="5gyVhZ17Jjo" role="2Oq$k0">
+                  <ref role="yHkDG" node="5gyVhZ17JkL" resolve="myNode" />
+                </node>
+                <node concept="yHkDv" id="7byHRlLCzrG" role="2OqNvi">
+                  <ref role="yHkD0" to="awpe:7byHRlLCxQG" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="5gyVhZ17Jjq" role="3cqZAp">
+            <node concept="3cpWsn" id="5gyVhZ17Jjr" role="3cpWs9">
+              <property role="TrG5h" value="panel" />
+              <node concept="3uibUv" id="5gyVhZ17Jjs" role="1tU5fm">
+                <ref role="3uigEE" to="dxuu:~JPanel" resolve="JPanel" />
+              </node>
+              <node concept="2ShNRf" id="5gyVhZ17Jjt" role="33vP2m">
+                <node concept="1pGfFk" id="5gyVhZ17Jju" role="2ShVmc">
+                  <ref role="37wK5l" to="dxuu:~JPanel.&lt;init&gt;(java.awt.LayoutManager)" resolve="JPanel" />
+                  <node concept="2ShNRf" id="5gyVhZ17Jjv" role="37wK5m">
+                    <node concept="1pGfFk" id="5gyVhZ17Jjw" role="2ShVmc">
+                      <ref role="37wK5l" to="z60i:~BorderLayout.&lt;init&gt;()" resolve="BorderLayout" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="5gyVhZ17Jjx" role="3cqZAp">
+            <node concept="2OqwBi" id="5gyVhZ17Jjy" role="3clFbG">
+              <node concept="37vLTw" id="3GM_nagTsO4" role="2Oq$k0">
+                <ref role="3cqZAo" node="5gyVhZ17Jjr" resolve="panel" />
+              </node>
+              <node concept="liA8E" id="5gyVhZ17Jj$" role="2OqNvi">
+                <ref role="37wK5l" to="z60i:~Container.add(java.awt.Component,java.lang.Object):void" resolve="add" />
+                <node concept="yHkD2" id="5gyVhZ17Jj_" role="37wK5m">
+                  <ref role="3cqZAo" node="5gyVhZ17Jja" resolve="myLabel" />
+                </node>
+                <node concept="10M0yZ" id="5gyVhZ17JjA" role="37wK5m">
+                  <ref role="1PxDUh" to="z60i:~BorderLayout" resolve="BorderLayout" />
+                  <ref role="3cqZAo" to="z60i:~BorderLayout.NORTH" resolve="NORTH" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="5gyVhZ17JjB" role="3cqZAp">
+            <node concept="2OqwBi" id="5gyVhZ17JjC" role="3clFbG">
+              <node concept="37vLTw" id="3GM_nagTsMA" role="2Oq$k0">
+                <ref role="3cqZAo" node="5gyVhZ17Jjr" resolve="panel" />
+              </node>
+              <node concept="liA8E" id="5gyVhZ17JjE" role="2OqNvi">
+                <ref role="37wK5l" to="z60i:~Container.add(java.awt.Component,java.lang.Object):void" resolve="add" />
+                <node concept="37vLTw" id="3GM_nagTtDD" role="37wK5m">
+                  <ref role="3cqZAo" node="5gyVhZ17Jjl" resolve="nodeChooser" />
+                </node>
+                <node concept="10M0yZ" id="5gyVhZ17JjG" role="37wK5m">
+                  <ref role="1PxDUh" to="z60i:~BorderLayout" resolve="BorderLayout" />
+                  <ref role="3cqZAo" to="z60i:~BorderLayout.CENTER" resolve="CENTER" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs8" id="5gyVhZ17JjI" role="3cqZAp">
+            <node concept="3cpWsn" id="5gyVhZ17JjJ" role="3cpWs9">
+              <property role="TrG5h" value="javaRunParametersEditor" />
+              <node concept="3uibUv" id="v01rbu3Tot" role="1tU5fm">
+                <ref role="3uigEE" to="go48:v01rbtVlXX" resolve="JavaConfigurationEditorComponent" />
+              </node>
+              <node concept="2OqwBi" id="5gyVhZ17JjL" role="33vP2m">
+                <node concept="yHkDH" id="5gyVhZ17JjM" role="2Oq$k0">
+                  <ref role="yHkDG" node="5gyVhZ17Jlr" resolve="runParameters" />
+                </node>
+                <node concept="yHkDv" id="29ovBt4WImB" role="2OqNvi">
+                  <ref role="yHkD0" to="go48:6woObKLBCk0" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="5gyVhZ17JjO" role="3cqZAp" />
+          <node concept="3cpWs8" id="5gyVhZ17JjP" role="3cqZAp">
+            <node concept="3cpWsn" id="5gyVhZ17JjQ" role="3cpWs9">
+              <property role="TrG5h" value="mainPanel" />
+              <node concept="3uibUv" id="5gyVhZ17JjR" role="1tU5fm">
+                <ref role="3uigEE" to="dxuu:~JPanel" resolve="JPanel" />
+              </node>
+              <node concept="2ShNRf" id="5gyVhZ17JjS" role="33vP2m">
+                <node concept="1pGfFk" id="5gyVhZ17JjT" role="2ShVmc">
+                  <ref role="37wK5l" to="dxuu:~JPanel.&lt;init&gt;(java.awt.LayoutManager)" resolve="JPanel" />
+                  <node concept="2ShNRf" id="5gyVhZ17JjU" role="37wK5m">
+                    <node concept="1pGfFk" id="5gyVhZ17JjV" role="2ShVmc">
+                      <ref role="37wK5l" to="z60i:~BorderLayout.&lt;init&gt;()" resolve="BorderLayout" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="5gyVhZ17JjW" role="3cqZAp">
+            <node concept="2OqwBi" id="5gyVhZ17JjX" role="3clFbG">
+              <node concept="37vLTw" id="3GM_nagTz1j" role="2Oq$k0">
+                <ref role="3cqZAo" node="5gyVhZ17JjQ" resolve="mainPanel" />
+              </node>
+              <node concept="liA8E" id="5gyVhZ17JjZ" role="2OqNvi">
+                <ref role="37wK5l" to="z60i:~Container.add(java.awt.Component,java.lang.Object):void" resolve="add" />
+                <node concept="37vLTw" id="3GM_nagTzcW" role="37wK5m">
+                  <ref role="3cqZAo" node="5gyVhZ17Jjr" resolve="panel" />
+                </node>
+                <node concept="10M0yZ" id="5gyVhZ17Jk1" role="37wK5m">
+                  <ref role="1PxDUh" to="z60i:~BorderLayout" resolve="BorderLayout" />
+                  <ref role="3cqZAo" to="z60i:~BorderLayout.NORTH" resolve="NORTH" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="5gyVhZ17Jk2" role="3cqZAp">
+            <node concept="2OqwBi" id="5gyVhZ17Jk3" role="3clFbG">
+              <node concept="37vLTw" id="3GM_nagTvvl" role="2Oq$k0">
+                <ref role="3cqZAo" node="5gyVhZ17JjQ" resolve="mainPanel" />
+              </node>
+              <node concept="liA8E" id="5gyVhZ17Jk5" role="2OqNvi">
+                <ref role="37wK5l" to="z60i:~Container.add(java.awt.Component,java.lang.Object):void" resolve="add" />
+                <node concept="37vLTw" id="3GM_nagTBzj" role="37wK5m">
+                  <ref role="3cqZAo" node="5gyVhZ17JjJ" resolve="javaRunParametersEditor" />
+                </node>
+                <node concept="10M0yZ" id="5gyVhZ17Jk7" role="37wK5m">
+                  <ref role="1PxDUh" to="z60i:~BorderLayout" resolve="BorderLayout" />
+                  <ref role="3cqZAo" to="z60i:~BorderLayout.CENTER" resolve="CENTER" />
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs6" id="5gyVhZ17Jk8" role="3cqZAp">
+            <node concept="37vLTw" id="3GM_nagTuDU" role="3cqZAk">
+              <ref role="3cqZAo" node="5gyVhZ17JjQ" resolve="mainPanel" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="yHkD7" id="5gyVhZ17Jka" role="yHkCL">
+        <node concept="3clFbS" id="5gyVhZ17Jkb" role="2VODD2">
+          <node concept="3clFbF" id="5gyVhZ17Jkc" role="3cqZAp">
+            <node concept="2OqwBi" id="5gyVhZ17Jkd" role="3clFbG">
+              <node concept="yHkDH" id="5gyVhZ17Jke" role="2Oq$k0">
+                <ref role="yHkDG" node="5gyVhZ17JkL" resolve="myNode" />
+              </node>
+              <node concept="yHkDv" id="5gyVhZ17Jkf" role="2OqNvi">
+                <ref role="yHkD0" to="awpe:7byHRlLCxQQ" />
+                <node concept="2OqwBi" id="5gyVhZ17Jkg" role="yHkDu">
+                  <node concept="yHkzx" id="5gyVhZ17Jkh" role="2Oq$k0" />
+                  <node concept="yHkDZ" id="5gyVhZ17Jki" role="2OqNvi">
+                    <ref role="yHkDY" node="5gyVhZ17JkL" resolve="myNode" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="5gyVhZ17Jkj" role="3cqZAp">
+            <node concept="2OqwBi" id="5gyVhZ17Jkk" role="3clFbG">
+              <node concept="yHkDH" id="5gyVhZ17Jkl" role="2Oq$k0">
+                <ref role="yHkDG" node="5gyVhZ17Jlr" resolve="runParameters" />
+              </node>
+              <node concept="yHkDv" id="5gyVhZ17Jkm" role="2OqNvi">
+                <ref role="yHkD0" to="go48:6woObKLBCk4" />
+                <node concept="2OqwBi" id="5gyVhZ17Jkn" role="yHkDu">
+                  <node concept="yHkzx" id="5gyVhZ17Jko" role="2Oq$k0" />
+                  <node concept="yHkDZ" id="5gyVhZ17Jkp" role="2OqNvi">
+                    <ref role="yHkDY" node="5gyVhZ17Jlr" resolve="runParameters" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="yHkDo" id="5gyVhZ17Jkq" role="yHkDe">
+        <node concept="3clFbS" id="5gyVhZ17Jkr" role="2VODD2">
+          <node concept="3clFbF" id="5gyVhZ17Jks" role="3cqZAp">
+            <node concept="2OqwBi" id="5gyVhZ17Jkt" role="3clFbG">
+              <node concept="yHkDH" id="5gyVhZ17Jku" role="2Oq$k0">
+                <ref role="yHkDG" node="5gyVhZ17JkL" resolve="myNode" />
+              </node>
+              <node concept="yHkDv" id="5gyVhZ17Jkv" role="2OqNvi">
+                <ref role="yHkD0" to="awpe:7byHRlLCxQZ" />
+                <node concept="2OqwBi" id="5gyVhZ17Jkw" role="yHkDu">
+                  <node concept="yHkzx" id="5gyVhZ17Jkx" role="2Oq$k0" />
+                  <node concept="yHkDZ" id="5gyVhZ17Jky" role="2OqNvi">
+                    <ref role="yHkDY" node="5gyVhZ17JkL" resolve="myNode" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="5gyVhZ17Jkz" role="3cqZAp">
+            <node concept="2OqwBi" id="5gyVhZ17Jk$" role="3clFbG">
+              <node concept="yHkDH" id="5gyVhZ17Jk_" role="2Oq$k0">
+                <ref role="yHkDG" node="5gyVhZ17Jlr" resolve="runParameters" />
+              </node>
+              <node concept="yHkDv" id="5gyVhZ17JkA" role="2OqNvi">
+                <ref role="yHkD0" to="go48:6woObKLBCkd" />
+                <node concept="2OqwBi" id="5gyVhZ17JkB" role="yHkDu">
+                  <node concept="yHkzx" id="5gyVhZ17JkC" role="2Oq$k0" />
+                  <node concept="yHkDZ" id="5gyVhZ17JkD" role="2OqNvi">
+                    <ref role="yHkDY" node="5gyVhZ17Jlr" resolve="runParameters" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="yHkDU" id="5gyVhZ17JkE" role="yHkCK">
+        <node concept="3clFbS" id="5gyVhZ17JkF" role="2VODD2">
+          <node concept="3clFbF" id="5gyVhZ17JkG" role="3cqZAp">
+            <node concept="2OqwBi" id="5gyVhZ17JkH" role="3clFbG">
+              <node concept="yHkDH" id="5gyVhZ17JkI" role="2Oq$k0">
+                <ref role="yHkDG" node="5gyVhZ17Jlr" resolve="runParameters" />
+              </node>
+              <node concept="yHkDv" id="29ovBt4WNgU" role="2OqNvi">
+                <ref role="yHkD0" to="go48:6woObKLBCkm" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1QGGSu" id="5gyVhZ17JkK" role="3GxumY" />
+    <node concept="yHkDC" id="5gyVhZ17JkL" role="yHkDi">
+      <property role="TrG5h" value="myNode" />
+      <node concept="yHkIc" id="5gyVhZ17JkM" role="1tU5fm">
+        <ref role="yHkHG" to="awpe:7byHRlLCxO1" resolve="NodeBySeveralConcepts" />
+      </node>
+      <node concept="2ShNRf" id="5gyVhZ17JkN" role="33vP2m">
+        <node concept="yHkDB" id="5gyVhZ17JkO" role="2ShVmc">
+          <ref role="yHkDA" to="awpe:7byHRlLCxO1" resolve="NodeBySeveralConcepts" />
+          <node concept="2ShNRf" id="7osd9LNy0F6" role="yHkDD">
+            <node concept="Tc6Ow" id="7osd9LNy4N2" role="2ShVmc">
+              <node concept="2pR195" id="7osd9LNyltN" role="HW$YZ">
+                <ref role="3uigEE" to="awpe:7osd9LNxQRM" resolve="NodesDescriptor" />
+              </node>
+              <node concept="2ry78W" id="7osd9LNy7uE" role="HW$Y0">
+                <ref role="2ryb1Q" to="awpe:7osd9LNxQRM" resolve="NodesDescriptor" />
+                <node concept="2r$n1x" id="7osd9LNy7uA" role="2r_Bvh">
+                  <ref role="2r$qp6" to="awpe:7osd9LNxR41" resolve="concept" />
+                  <node concept="35c_gC" id="_dGddVUVxA" role="2r_lH1">
+                    <ref role="35c_gD" to="85g0:Juyp1w2Jt3" resolve="Worksheet" />
+                  </node>
+                </node>
+                <node concept="2r$n1x" id="7osd9LNy7uC" role="2r_Bvh">
+                  <ref role="2r$qp6" to="awpe:7osd9LNxRxi" resolve="filter" />
+                  <node concept="1bVj0M" id="5gyVhZ17JkV" role="2r_lH1">
+                    <node concept="3clFbS" id="5gyVhZ17JkW" role="1bW5cS">
+                      <node concept="3cpWs6" id="4jnZTahiW5i" role="3cqZAp">
+                        <node concept="3clFbT" id="4jnZTahiZMQ" role="3cqZAk">
+                          <property role="3clFbU" value="true" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="37vLTG" id="5gyVhZ17Jl2" role="1bW2Oz">
+                      <property role="TrG5h" value="node" />
+                      <node concept="3Tqbb2" id="5gyVhZ17Jl3" role="1tU5fm" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="yHkDC" id="5gyVhZ17Jlr" role="yHkDi">
+      <property role="TrG5h" value="runParameters" />
+      <node concept="yHkIc" id="6oDdG_XwVAT" role="1tU5fm">
+        <ref role="yHkHG" to="go48:6woObKLBCjU" resolve="JavaRunParameters1" />
+      </node>
+      <node concept="2ShNRf" id="6oDdG_XxkYo" role="33vP2m">
+        <node concept="yHkDB" id="6oDdG_XxlHJ" role="2ShVmc">
+          <ref role="yHkDA" to="go48:6woObKLBCjU" resolve="JavaRunParameters1" />
+          <node concept="2OqwBi" id="6oDdG_Xxohg" role="yHkDD">
+            <node concept="2WthIp" id="6oDdG_Xxmtd" role="2Oq$k0" />
+            <node concept="3a8Xsn" id="6oDdG_Xxq9b" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="yHkDk" id="5gyVhZ17Jlv" role="yHkHj">
+      <node concept="3clFbS" id="5gyVhZ17Jlw" role="2VODD2">
+        <node concept="3clFbF" id="5gyVhZ17Jlx" role="3cqZAp">
+          <node concept="2OqwBi" id="qCQmZS53r7" role="3clFbG">
+            <node concept="2OqwBi" id="5gyVhZ17Jlz" role="2Oq$k0">
+              <node concept="2WthIp" id="5gyVhZ17Jl$" role="2Oq$k0" />
+              <node concept="yHkDZ" id="5gyVhZ17Jl_" role="2OqNvi">
+                <ref role="yHkDY" node="5gyVhZ17JkL" resolve="myNode" />
+              </node>
+            </node>
+            <node concept="yHkDI" id="qCQmZS543C" role="2OqNvi" />
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="3wDVqV" id="5gyVhZ17Jm9">
+    <property role="TrG5h" value="Functional Application" />
+    <property role="3GE5qa" value="" />
+    <node concept="1QGGSu" id="5gyVhZ17Jma" role="1bitO_" />
+  </node>
+  <node concept="RBi3j" id="5gyVhZ17Jmb">
+    <property role="35f5FB" value="true" />
+    <property role="3c$X6f" value="true" />
+    <property role="3GE5qa" value="" />
+    <property role="3gLNDv" value="configuration" />
+    <ref role="yIonz" node="5gyVhZ17Jj8" resolve="Functional" />
+    <node concept="yYvg6" id="5gyVhZ17Jmc" role="yYvgT">
+      <ref role="yYvg7" to="eva:4KDfkUwMkVJ" resolve="MakeNodePointers" />
+      <node concept="2ShNRf" id="5gyVhZ17Jmd" role="1ZwhtC">
+        <node concept="Tc6Ow" id="5gyVhZ17Jme" role="2ShVmc">
+          <node concept="3uibUv" id="5gyVhZ17Jmf" role="HW$YZ">
+            <ref role="3uigEE" to="mhbf:~SNodeReference" resolve="SNodeReference" />
+          </node>
+          <node concept="2OqwBi" id="5gyVhZ17Jmg" role="HW$Y0">
+            <node concept="2XshWL" id="5h4fo9Gsu5n" role="2OqNvi">
+              <ref role="2WH_rO" to="awpe:7byHRlLCxOy" resolve="getNode" />
+            </node>
+            <node concept="2OqwBi" id="5gyVhZ17Jmi" role="2Oq$k0">
+              <node concept="RBKsg" id="5gyVhZ17Jmj" role="2Oq$k0" />
+              <node concept="yHkDZ" id="5gyVhZ17Jmk" role="2OqNvi">
+                <ref role="yHkDY" node="5gyVhZ17JkL" resolve="myNode" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="3CCWSg" id="5gyVhZ17Jml" role="35uJNn">
+      <node concept="3clFbS" id="5gyVhZ17Jmm" role="2VODD2">
+        <node concept="3cpWs8" id="5gyVhZ17Jmn" role="3cqZAp">
+          <node concept="3cpWsn" id="5gyVhZ17Jmo" role="3cpWs9">
+            <property role="TrG5h" value="console" />
+            <property role="3TUv4t" value="true" />
+            <node concept="2bNAC1" id="5gyVhZ17Jmp" role="1tU5fm" />
+            <node concept="2ShNRf" id="5gyVhZ17Jmq" role="33vP2m">
+              <node concept="2bNoKo" id="5gyVhZ17Jmr" role="2ShVmc">
+                <node concept="21ER0p" id="5gyVhZ17Jms" role="2bNoDv" />
+                <node concept="3clFbT" id="5gyVhZ17Jmt" role="2bNoDs">
+                  <property role="3clFbU" value="false" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="5gyVhZ17Jmu" role="3cqZAp">
+          <node concept="2OqwBi" id="5gyVhZ17Jmv" role="3clFbG">
+            <node concept="37vLTw" id="3GM_nagTy$P" role="2Oq$k0">
+              <ref role="3cqZAo" node="5gyVhZ17Jmo" resolve="console" />
+            </node>
+            <node concept="liA8E" id="5gyVhZ17Jmx" role="2OqNvi">
+              <ref role="37wK5l" to="cjdg:~ConsoleView.addMessageFilter(com.intellij.execution.filters.Filter):void" resolve="addMessageFilter" />
+              <node concept="2ShNRf" id="5gyVhZ17Jmy" role="37wK5m">
+                <node concept="1pGfFk" id="5gyVhZ17Jmz" role="2ShVmc">
+                  <ref role="37wK5l" to="tprs:3EnpNH2_TVP" resolve="StandaloneMPSStackTraceFilter" />
+                  <node concept="21ER0p" id="jcVyxyAfx3" role="37wK5m" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4jnZTahjXD7" role="3cqZAp" />
+        <node concept="3cpWs8" id="25rknuvGQRA" role="3cqZAp">
+          <node concept="3cpWsn" id="25rknuvGQRB" role="3cpWs9">
+            <property role="TrG5h" value="pointer" />
+            <property role="3TUv4t" value="true" />
+            <node concept="3uibUv" id="2P21tSVnN1M" role="1tU5fm">
+              <ref role="3uigEE" to="mhbf:~SNodeReference" resolve="SNodeReference" />
+            </node>
+            <node concept="2OqwBi" id="25rknuvGQRC" role="33vP2m">
+              <node concept="2XshWL" id="25rknuvGQRD" role="2OqNvi">
+                <ref role="2WH_rO" to="awpe:7byHRlLCxOy" resolve="getNode" />
+              </node>
+              <node concept="2OqwBi" id="25rknuvGQRE" role="2Oq$k0">
+                <node concept="RBKsg" id="25rknuvGQRF" role="2Oq$k0" />
+                <node concept="yHkDZ" id="25rknuvGQRG" role="2OqNvi">
+                  <ref role="yHkDY" node="5gyVhZ17JkL" resolve="myNode" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbJ" id="25rknuvH4Ne" role="3cqZAp">
+          <node concept="3clFbS" id="25rknuvH4Nh" role="3clFbx">
+            <node concept="3clFbF" id="6wvy$c2F7Ip" role="3cqZAp">
+              <node concept="2OqwBi" id="6wvy$c2F877" role="3clFbG">
+                <node concept="37vLTw" id="6wvy$c2F7In" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5gyVhZ17Jmo" resolve="console" />
+                </node>
+                <node concept="liA8E" id="6wvy$c2F8Kx" role="2OqNvi">
+                  <ref role="37wK5l" to="v23q:~Disposable.dispose():void" resolve="dispose" />
+                </node>
+              </node>
+            </node>
+            <node concept="2LYoGF" id="25rknuvH5yh" role="3cqZAp">
+              <node concept="Xl_RD" id="25rknuvH5DP" role="2LYoNm">
+                <property role="Xl_RC" value="No Worksheet selected." />
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbC" id="25rknuvH53j" role="3clFbw">
+            <node concept="10Nm6u" id="25rknuvH56i" role="3uHU7w" />
+            <node concept="37vLTw" id="25rknuvH4Vd" role="3uHU7B">
+              <ref role="3cqZAo" node="25rknuvGQRB" resolve="pointer" />
+            </node>
+          </node>
+          <node concept="9aQIb" id="4jnZTahk0gJ" role="9aQIa">
+            <node concept="3clFbS" id="4jnZTahk0gK" role="9aQI4">
+              <node concept="3cpWs8" id="4jnZTahk3$X" role="3cqZAp">
+                <node concept="3cpWsn" id="4jnZTahk3$Y" role="3cpWs9">
+                  <property role="TrG5h" value="repository" />
+                  <property role="3TUv4t" value="true" />
+                  <node concept="3uibUv" id="4jnZTahk3$W" role="1tU5fm">
+                    <ref role="3uigEE" to="lui2:~SRepository" resolve="SRepository" />
+                  </node>
+                  <node concept="2YIFZM" id="4jnZTahk3$Z" role="33vP2m">
+                    <ref role="37wK5l" to="alof:~ProjectHelper.getProjectRepository(com.intellij.openapi.project.Project):org.jetbrains.mps.openapi.module.SRepository" resolve="getProjectRepository" />
+                    <ref role="1Pybhc" to="alof:~ProjectHelper" resolve="ProjectHelper" />
+                    <node concept="21ER0p" id="4jnZTahk3_0" role="37wK5m" />
+                  </node>
+                </node>
+              </node>
+              <node concept="3cpWs8" id="7P2vbT3rWzR" role="3cqZAp">
+                <node concept="3cpWsn" id="7P2vbT3rWzS" role="3cpWs9">
+                  <property role="TrG5h" value="module" />
+                  <property role="3TUv4t" value="false" />
+                  <node concept="3uibUv" id="7P2vbT3rWzK" role="1tU5fm">
+                    <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+                  </node>
+                  <node concept="10Nm6u" id="7P2vbT3s83R" role="33vP2m" />
+                </node>
+              </node>
+              <node concept="3cpWs8" id="7P2vbT3sfMU" role="3cqZAp">
+                <node concept="3cpWsn" id="7P2vbT3sfMV" role="3cpWs9">
+                  <property role="TrG5h" value="classpath" />
+                  <node concept="_YKpA" id="7P2vbT3sfMG" role="1tU5fm">
+                    <node concept="17QB3L" id="7P2vbT3sfMJ" role="_ZDj9" />
+                  </node>
+                  <node concept="10Nm6u" id="7P2vbT3sgtn" role="33vP2m" />
+                </node>
+              </node>
+              <node concept="3cpWs8" id="7P2vbT3spnb" role="3cqZAp">
+                <node concept="3cpWsn" id="7P2vbT3spne" role="3cpWs9">
+                  <property role="TrG5h" value="namespace" />
+                  <node concept="17QB3L" id="7P2vbT3spn9" role="1tU5fm" />
+                  <node concept="10Nm6u" id="7P2vbT3spIZ" role="33vP2m" />
+                </node>
+              </node>
+              <node concept="1QHqEK" id="7P2vbT3s7cr" role="3cqZAp">
+                <node concept="1QHqEC" id="7P2vbT3s7ct" role="1QHqEI">
+                  <node concept="3clFbS" id="7P2vbT3s7cv" role="1bW5cS">
+                    <node concept="3cpWs8" id="7P2vbT3sowh" role="3cqZAp">
+                      <node concept="3cpWsn" id="7P2vbT3sowi" role="3cpWs9">
+                        <property role="TrG5h" value="resolved" />
+                        <property role="3TUv4t" value="true" />
+                        <node concept="3Tqbb2" id="7P2vbT3soW6" role="1tU5fm" />
+                        <node concept="2OqwBi" id="7P2vbT3sowj" role="33vP2m">
+                          <node concept="37vLTw" id="7P2vbT3sowk" role="2Oq$k0">
+                            <ref role="3cqZAo" node="25rknuvGQRB" resolve="pointer" />
+                          </node>
+                          <node concept="liA8E" id="7P2vbT3sowl" role="2OqNvi">
+                            <ref role="37wK5l" to="mhbf:~SNodeReference.resolve(org.jetbrains.mps.openapi.module.SRepository):org.jetbrains.mps.openapi.model.SNode" resolve="resolve" />
+                            <node concept="37vLTw" id="7P2vbT3sowm" role="37wK5m">
+                              <ref role="3cqZAo" node="4jnZTahk3$Y" resolve="repository" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3cpWs8" id="7P2vbT3swGu" role="3cqZAp">
+                      <node concept="3cpWsn" id="7P2vbT3swGv" role="3cpWs9">
+                        <property role="TrG5h" value="model" />
+                        <property role="3TUv4t" value="true" />
+                        <node concept="3uibUv" id="7P2vbT3swGe" role="1tU5fm">
+                          <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
+                        </node>
+                        <node concept="2OqwBi" id="7P2vbT3swGw" role="33vP2m">
+                          <node concept="2JrnkZ" id="7P2vbT3swGx" role="2Oq$k0">
+                            <node concept="37vLTw" id="7P2vbT3swGy" role="2JrQYb">
+                              <ref role="3cqZAo" node="7P2vbT3sowi" resolve="resolved" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="7P2vbT3swGz" role="2OqNvi">
+                            <ref role="37wK5l" to="mhbf:~SNode.getModel():org.jetbrains.mps.openapi.model.SModel" resolve="getModel" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="7P2vbT3s8fd" role="3cqZAp">
+                      <node concept="37vLTI" id="7P2vbT3s8rl" role="3clFbG">
+                        <node concept="37vLTw" id="7P2vbT3s8fc" role="37vLTJ">
+                          <ref role="3cqZAo" node="7P2vbT3rWzS" resolve="module" />
+                        </node>
+                        <node concept="2OqwBi" id="7P2vbT3rWzT" role="37vLTx">
+                          <node concept="37vLTw" id="7P2vbT3swG_" role="2Oq$k0">
+                            <ref role="3cqZAo" node="7P2vbT3swGv" resolve="model" />
+                          </node>
+                          <node concept="liA8E" id="7P2vbT3rW$0" role="2OqNvi">
+                            <ref role="37wK5l" to="mhbf:~SModel.getModule():org.jetbrains.mps.openapi.module.SModule" resolve="getModule" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="15s5l7" id="7P2vbT3srl2" role="lGtFl" />
+                    </node>
+                    <node concept="3clFbF" id="7P2vbT3srDO" role="3cqZAp">
+                      <node concept="37vLTI" id="7P2vbT3ss6G" role="3clFbG">
+                        <node concept="2OqwBi" id="7P2vbT3svmS" role="37vLTx">
+                          <node concept="2OqwBi" id="7P2vbT3sua$" role="2Oq$k0">
+                            <node concept="37vLTw" id="7P2vbT3swG$" role="2Oq$k0">
+                              <ref role="3cqZAo" node="7P2vbT3swGv" resolve="model" />
+                            </node>
+                            <node concept="liA8E" id="7P2vbT3suZ$" role="2OqNvi">
+                              <ref role="37wK5l" to="mhbf:~SModel.getName():org.jetbrains.mps.openapi.model.SModelName" resolve="getName" />
+                            </node>
+                          </node>
+                          <node concept="liA8E" id="7P2vbT3swp2" role="2OqNvi">
+                            <ref role="37wK5l" to="mhbf:~SModelName.getLongName():java.lang.String" resolve="getLongName" />
+                          </node>
+                        </node>
+                        <node concept="37vLTw" id="7P2vbT3srDM" role="37vLTJ">
+                          <ref role="3cqZAo" node="7P2vbT3spne" resolve="namespace" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbF" id="7P2vbT3sgU8" role="3cqZAp">
+                      <node concept="37vLTI" id="7P2vbT3shJe" role="3clFbG">
+                        <node concept="37vLTw" id="7P2vbT3sgU6" role="37vLTJ">
+                          <ref role="3cqZAo" node="7P2vbT3sfMV" resolve="classpath" />
+                        </node>
+                        <node concept="2YIFZM" id="7P2vbT3sfMW" role="37vLTx">
+                          <ref role="1Pybhc" node="7P2vbT3r$b3" resolve="ExecutorUtil" />
+                          <ref role="37wK5l" node="7P2vbT3rQ7L" resolve="getClasspath" />
+                          <node concept="2ShNRf" id="7P2vbT3sfMX" role="37wK5m">
+                            <node concept="2HTt$P" id="7P2vbT3sfMY" role="2ShVmc">
+                              <node concept="3uibUv" id="7P2vbT3sfMZ" role="2HTBi0">
+                                <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+                              </node>
+                              <node concept="37vLTw" id="7P2vbT3sfN0" role="2HTEbv">
+                                <ref role="3cqZAo" node="7P2vbT3rWzS" resolve="module" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="7P2vbT3s7jp" role="ukAjM">
+                  <ref role="3cqZAo" node="4jnZTahk3$Y" resolve="repository" />
+                </node>
+              </node>
+              <node concept="yIgYw" id="7P2vbT3rvNo" role="3cqZAp">
+                <node concept="2LYoGx" id="7P2vbT3rvNp" role="3cqZAk">
+                  <ref role="3rFKlk" to="go48:14R2qyOBxa2" resolve="java" />
+                  <node concept="2LYoGL" id="7P2vbT3rvNq" role="2LYoGw">
+                    <ref role="2LYoGK" to="go48:14R2qyOBxah" resolve="className" />
+                    <node concept="3cpWs3" id="7P2vbT3sxky" role="2LYoGN">
+                      <node concept="37vLTw" id="7P2vbT3sxlk" role="3uHU7B">
+                        <ref role="3cqZAo" node="7P2vbT3spne" resolve="namespace" />
+                      </node>
+                      <node concept="Xl_RD" id="7P2vbT3rvNr" role="3uHU7w">
+                        <property role="Xl_RC" value=".Main" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2LYoGL" id="7P2vbT3rCUt" role="2LYoGw">
+                    <ref role="2LYoGK" to="go48:14R2qyOBxaf" resolve="virtualMachineParameter" />
+                    <node concept="2EnYce" id="7P2vbT3rMCn" role="2LYoGN">
+                      <node concept="2EnYce" id="7P2vbT3rJJC" role="2Oq$k0">
+                        <node concept="2EnYce" id="7P2vbT3rIO$" role="2Oq$k0">
+                          <node concept="RBKsg" id="7P2vbT3rD3g" role="2Oq$k0" />
+                          <node concept="yHkDZ" id="7P2vbT3rJ5U" role="2OqNvi">
+                            <ref role="yHkDY" node="5gyVhZ17Jlr" resolve="runParameters" />
+                          </node>
+                        </node>
+                        <node concept="yHkDZ" id="7P2vbT3rK4n" role="2OqNvi">
+                          <ref role="yHkDY" to="go48:6woObKLBCks" resolve="myJavaRunParameters" />
+                        </node>
+                      </node>
+                      <node concept="2sxana" id="7P2vbT3rO6r" role="2OqNvi">
+                        <ref role="2sxfKC" to="go48:14R2qyOCsWE" resolve="vmOptions" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="2LYoGL" id="7P2vbT3rO76" role="2LYoGw">
+                    <ref role="2LYoGK" to="go48:14R2qyOBxaj" resolve="classPath" />
+                    <node concept="37vLTw" id="7P2vbT3sfN1" role="2LYoGN">
+                      <ref role="3cqZAo" node="7P2vbT3sfMV" resolve="classpath" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="37vLTw" id="7P2vbT3rvNs" role="2bO3kM">
+                  <ref role="3cqZAo" node="5gyVhZ17Jmo" resolve="console" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="2w4XYM" id="5gyVhZ17JmN">
+    <property role="3GE5qa" value="" />
+    <node concept="yHkHH" id="5gyVhZ17JmO" role="2w4Pho">
+      <ref role="yHkHG" node="5gyVhZ17Jj8" resolve="Functional" />
+    </node>
+    <node concept="2w4N4h" id="5gyVhZ17JmP" role="2w4N4r">
+      <node concept="1wNYB6" id="4$cur0DL_2c" role="1WFzRM">
+        <node concept="3clFbS" id="4$cur0DLE$z" role="2VODD2">
+          <node concept="3cpWs6" id="5aSLaYRTwSb" role="3cqZAp">
+            <node concept="2OqwBi" id="5aSLaYRTxmg" role="3cqZAk">
+              <node concept="nyUVq" id="7xK6LiGbVhZ" role="2Oq$k0" />
+              <node concept="2XshWL" id="5aSLaYRTxD1" role="2OqNvi">
+                <ref role="2WH_rO" node="5aSLaYRTp9U" resolve="isFromContext" />
+                <node concept="nzYpQ" id="4aK5w_lihoV" role="2XxRq1" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2w4N5O" id="5gyVhZ17JmQ" role="30xZXv">
+        <node concept="3clFbS" id="5gyVhZ17JmR" role="2VODD2">
+          <node concept="3cpWs8" id="5gyVhZ17Jn1" role="3cqZAp">
+            <node concept="3cpWsn" id="5gyVhZ17Jn2" role="3cpWs9">
+              <property role="TrG5h" value="configuration" />
+              <property role="3TUv4t" value="true" />
+              <node concept="yHkHH" id="5gyVhZ17Jn3" role="1tU5fm">
+                <ref role="yHkHG" node="5gyVhZ17Jj8" resolve="Functional" />
+              </node>
+              <node concept="2ShNRf" id="5gyVhZ17Jn4" role="33vP2m">
+                <node concept="30w_07" id="5gyVhZ17Jn5" role="2ShVmc">
+                  <ref role="30w_06" node="5gyVhZ17Jj8" resolve="Functional" />
+                  <node concept="3cpWs3" id="5gyVhZ17Jn6" role="uV2A8">
+                    <node concept="2OqwBi" id="5gyVhZ17Jn7" role="3uHU7w">
+                      <node concept="30xZXu" id="5gyVhZ17Jn8" role="2Oq$k0" />
+                      <node concept="3TrcHB" id="4jnZTahiDjm" role="2OqNvi">
+                        <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+                      </node>
+                    </node>
+                    <node concept="Xl_RD" id="5gyVhZ17Jna" role="3uHU7B">
+                      <property role="Xl_RC" value="Worksheet " />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="5gyVhZ17Jnb" role="3cqZAp">
+            <node concept="2OqwBi" id="5gyVhZ17Jnc" role="3clFbG">
+              <node concept="2OqwBi" id="5gyVhZ17Jnd" role="2Oq$k0">
+                <node concept="37vLTw" id="3GM_nagTrag" role="2Oq$k0">
+                  <ref role="3cqZAo" node="5gyVhZ17Jn2" resolve="configuration" />
+                </node>
+                <node concept="yHkDZ" id="5gyVhZ17Jnf" role="2OqNvi">
+                  <ref role="yHkDY" node="5gyVhZ17JkL" resolve="myNode" />
+                </node>
+              </node>
+              <node concept="2XshWL" id="5gyVhZ17Jng" role="2OqNvi">
+                <ref role="2WH_rO" to="awpe:7byHRlLCxOZ" resolve="setNode" />
+                <node concept="30xZXu" id="5gyVhZ17Jnh" role="2XxRq1" />
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWs6" id="5gyVhZ17Jni" role="3cqZAp">
+            <node concept="37vLTw" id="3GM_nagTxDA" role="3cqZAk">
+              <ref role="3cqZAo" node="5gyVhZ17Jn2" resolve="configuration" />
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="2nMXjs" id="5gyVhZ17Jnk" role="2nMwby">
+        <ref role="2nMXoJ" to="85g0:Juyp1w2Jt3" resolve="Worksheet" />
+      </node>
+    </node>
+  </node>
+  <node concept="2DaZZR" id="4jnZTahj5Bl" />
+  <node concept="312cEu" id="7P2vbT3r$b3">
+    <property role="TrG5h" value="ExecutorUtil" />
+    <node concept="2tJIrI" id="7P2vbT3r$bt" role="jymVt" />
+    <node concept="2YIFZL" id="7P2vbT3rQ7L" role="jymVt">
+      <property role="TrG5h" value="getClasspath" />
+      <property role="DiZV1" value="false" />
+      <property role="od$2w" value="false" />
+      <property role="2aFKle" value="false" />
+      <node concept="3clFbS" id="7P2vbT3rQ7S" role="3clF47">
+        <node concept="3cpWs8" id="7P2vbT3rQ7T" role="3cqZAp">
+          <node concept="3cpWsn" id="7P2vbT3rQ7U" role="3cpWs9">
+            <property role="TrG5h" value="classpath" />
+            <node concept="3uibUv" id="7P2vbT3rQ7V" role="1tU5fm">
+              <ref role="3uigEE" to="33ny:~Set" resolve="Set" />
+              <node concept="17QB3L" id="7P2vbT3rQ7W" role="11_B2D" />
+            </node>
+            <node concept="2YIFZM" id="7P2vbT3rQ7X" role="33vP2m">
+              <ref role="37wK5l" to="b0pz:~JavaModuleOperations.collectExecuteClasspath(org.jetbrains.mps.openapi.module.SModule...):java.util.Set" resolve="collectExecuteClasspath" />
+              <ref role="1Pybhc" to="b0pz:~JavaModuleOperations" resolve="JavaModuleOperations" />
+              <node concept="2OqwBi" id="7P2vbT3rQ7Y" role="37wK5m">
+                <node concept="2OqwBi" id="7P2vbT3rQ7Z" role="2Oq$k0">
+                  <node concept="37vLTw" id="7P2vbT3rQ80" role="2Oq$k0">
+                    <ref role="3cqZAo" node="7P2vbT3rQ7N" resolve="modules" />
+                  </node>
+                  <node concept="ANE8D" id="7P2vbT3rQ81" role="2OqNvi" />
+                </node>
+                <node concept="3_kTaI" id="7P2vbT3rQ82" role="2OqNvi" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="7P2vbT3rQ83" role="3cqZAp">
+          <node concept="2OqwBi" id="7P2vbT3rQ84" role="3clFbG">
+            <node concept="liA8E" id="7P2vbT3rQ85" role="2OqNvi">
+              <ref role="37wK5l" to="33ny:~Set.removeAll(java.util.Collection):boolean" resolve="removeAll" />
+              <node concept="2OqwBi" id="7P2vbT3rQ86" role="37wK5m">
+                <node concept="liA8E" id="7P2vbT3rQ87" role="2OqNvi">
+                  <ref role="37wK5l" to="w0gx:~ModuleDescriptor.getAdditionalJavaStubPaths():java.util.Collection" resolve="getAdditionalJavaStubPaths" />
+                </node>
+                <node concept="2OqwBi" id="7P2vbT3rQ88" role="2Oq$k0">
+                  <node concept="liA8E" id="7P2vbT3rQ89" role="2OqNvi">
+                    <ref role="37wK5l" to="z1c3:~AbstractModule.getModuleDescriptor():jetbrains.mps.project.structure.modules.ModuleDescriptor" resolve="getModuleDescriptor" />
+                  </node>
+                  <node concept="1eOMI4" id="7P2vbT3rQ8a" role="2Oq$k0">
+                    <node concept="10QFUN" id="7P2vbT3rQ8b" role="1eOMHV">
+                      <node concept="3uibUv" id="7P2vbT3rQ8c" role="10QFUM">
+                        <ref role="3uigEE" to="z1c3:~AbstractModule" resolve="AbstractModule" />
+                      </node>
+                      <node concept="3rM5sP" id="7P2vbT3rQ8d" role="10QFUP">
+                        <property role="3rM5sR" value="6354ebe7-c22a-4a0f-ac54-50b52ab9b065" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="37vLTw" id="7P2vbT3rQ8e" role="2Oq$k0">
+              <ref role="3cqZAo" node="7P2vbT3rQ7U" resolve="classpath" />
+            </node>
+          </node>
+          <node concept="15s5l7" id="1WKLEm1DY_1" role="lGtFl" />
+        </node>
+        <node concept="3cpWs6" id="7P2vbT3rQ8f" role="3cqZAp">
+          <node concept="2ShNRf" id="7P2vbT3rQ8g" role="3cqZAk">
+            <node concept="1pGfFk" id="7P2vbT3rQ8h" role="2ShVmc">
+              <ref role="37wK5l" to="33ny:~ArrayList.&lt;init&gt;(java.util.Collection)" resolve="ArrayList" />
+              <node concept="17QB3L" id="7P2vbT3rQ8i" role="1pMfVU" />
+              <node concept="37vLTw" id="7P2vbT3rQ8j" role="37wK5m">
+                <ref role="3cqZAo" node="7P2vbT3rQ7U" resolve="classpath" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="_YKpA" id="7P2vbT3rQ7Q" role="3clF45">
+        <node concept="17QB3L" id="7P2vbT3rQ7R" role="_ZDj9" />
+      </node>
+      <node concept="37vLTG" id="7P2vbT3rQ7N" role="3clF46">
+        <property role="TrG5h" value="modules" />
+        <node concept="A3Dl8" id="7P2vbT3rQ7O" role="1tU5fm">
+          <node concept="3uibUv" id="7P2vbT3rQ7P" role="A3Ik2">
+            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="7P2vbT3rQ8k" role="1B3o_S" />
+    </node>
+    <node concept="2tJIrI" id="7P2vbT3r$b_" role="jymVt" />
+    <node concept="3Tm1VV" id="7P2vbT3r$b4" role="1B3o_S" />
+  </node>
+</model>
+

--- a/mps-workshop-2-itemis/solutions/mps.workshop.executor/mps.workshop.executor.msd
+++ b/mps-workshop-2-itemis/solutions/mps.workshop.executor/mps.workshop.executor.msd
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="mps.workshop.executor" uuid="3b867603-78dc-4c14-b079-04ee1c093900" moduleVersion="0" pluginKind="PLUGIN_OTHER" compileInMPS="true">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <sourcePath />
+  <dependencies>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="false">498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)</dependency>
+    <dependency reexport="false">3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)</dependency>
+    <dependency reexport="false">ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)</dependency>
+    <dependency reexport="false">742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)</dependency>
+    <dependency reexport="false">6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)</dependency>
+    <dependency reexport="false">8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)</dependency>
+    <dependency reexport="false">04b376d5-fc16-403b-a344-c68b30193c6a(jetbrains.mps.execution.library)</dependency>
+    <dependency reexport="false">22250116-183c-4e90-8450-b6a13dd8998b(jetbrains.mps.baseLanguage.execution.util)</dependency>
+    <dependency reexport="false">019b622b-0aef-4dd3-86d0-4eef01f3f6bb(jetbrains.mps.ide)</dependency>
+    <dependency reexport="false">933a68f9-aab6-401b-b5c5-5ca7783dce5f(jetbrains.mps.execution.configurations.pluginSolution)</dependency>
+    <dependency reexport="false">86441d7a-e194-42da-81a5-2161ec62a379(MPS.Workbench)</dependency>
+    <dependency reexport="false">c9c683f9-1916-4ea4-bc6e-ec5b2a10659d(mps.workshop.lang)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="5" />
+    <language slang="l:774bf8a0-62e5-41e1-af63-f4812e60e48b:jetbrains.mps.baseLanguage.checkedDots" version="0" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="0" />
+    <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+    <language slang="l:fbc14279-5e2a-4c87-a5d1-5f7061e6c456:jetbrains.mps.debugger.api.lang" version="1" />
+    <language slang="l:f3347d8a-0e79-4f35-8ac9-1574f25c986f:jetbrains.mps.execution.commands" version="0" />
+    <language slang="l:73c1a490-99fa-4d0d-8292-b8985697c74b:jetbrains.mps.execution.common" version="0" />
+    <language slang="l:22e72e4c-0f69-46ce-8403-6750153aa615:jetbrains.mps.execution.configurations" version="1" />
+    <language slang="l:756e911c-3f1f-4a48-bdf5-a2ceb91b723c:jetbrains.mps.execution.settings" version="0" />
+    <language slang="l:63650c59-16c8-498a-99c8-005c7ee9515d:jetbrains.mps.lang.access" version="0" />
+    <language slang="l:fe9d76d7-5809-45c9-ae28-a40915b4d6ff:jetbrains.mps.lang.checkedName" version="0" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="1" />
+    <language slang="l:28f9e497-3b42-4291-aeba-0a1039153ab1:jetbrains.mps.lang.plugin" version="2" />
+    <language slang="l:ef7bf5ac-d06c-4342-b11d-e42104eb9343:jetbrains.mps.lang.plugin.standalone" version="0" />
+    <language slang="l:982eb8df-2c96-4bd7-9963-11712ea622e5:jetbrains.mps.lang.resources" version="2" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="8" />
+    <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="6" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+    <module reference="86441d7a-e194-42da-81a5-2161ec62a379(MPS.Workbench)" version="0" />
+    <module reference="22250116-183c-4e90-8450-b6a13dd8998b(jetbrains.mps.baseLanguage.execution.util)" version="0" />
+    <module reference="933a68f9-aab6-401b-b5c5-5ca7783dce5f(jetbrains.mps.execution.configurations.pluginSolution)" version="0" />
+    <module reference="04b376d5-fc16-403b-a344-c68b30193c6a(jetbrains.mps.execution.library)" version="0" />
+    <module reference="019b622b-0aef-4dd3-86d0-4eef01f3f6bb(jetbrains.mps.ide)" version="0" />
+    <module reference="25092e07-e655-497c-92fb-558a8e3080ed(jetbrains.mps.ide.ui)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
+    <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
+    <module reference="20351dc3-a2df-46f5-b667-fc9adab1f1c9(jetbrains.mps.make)" version="0" />
+    <module reference="a1250a4d-c090-42c3-ad7c-d298a3357dd4(jetbrains.mps.make.runtime)" version="0" />
+    <module reference="3b867603-78dc-4c14-b079-04ee1c093900(mps.workshop.executor)" version="0" />
+    <module reference="c9c683f9-1916-4ea4-bc6e-ec5b2a10659d(mps.workshop.lang)" version="0" />
+  </dependencyVersions>
+</solution>
+

--- a/mps-workshop-2-itemis/solutions/mps.workshop.interpreter/models/plugin.mps
+++ b/mps-workshop-2-itemis/solutions/mps.workshop.interpreter/models/plugin.mps
@@ -1,0 +1,526 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:020f90a8-ee23-470d-af3e-0fbebdc45a9f(mps.workshop.interpreter.plugin)">
+  <persistence version="9" />
+  <languages>
+    <use id="47f075a6-558e-4640-a606-7ce0236c8023" name="com.mbeddr.mpsutil.interpreter" version="0" />
+    <use id="ef7bf5ac-d06c-4342-b11d-e42104eb9343" name="jetbrains.mps.lang.plugin.standalone" version="0" />
+    <use id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging" version="0" />
+    <devkit ref="fbc25dd2-5da4-483a-8b19-70928e1b62d7(jetbrains.mps.devkit.general-purpose)" />
+  </languages>
+  <imports>
+    <import index="85g0" ref="r:3255fe94-9102-4828-b2d9-432a6ecad106(mps.workshop.lang.structure)" />
+    <import index="xlxw" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.math(JDK/)" />
+    <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
+    <import index="2ahs" ref="r:ea6cf71d-29d2-478d-8027-a9f4a4de53c4(com.mbeddr.mpsutil.interpreter.rt)" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="ng" index="2tJIrI" />
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1164879751025" name="jetbrains.mps.baseLanguage.structure.TryCatchStatement" flags="nn" index="SfApY">
+        <child id="1164879758292" name="body" index="SfCbr" />
+        <child id="1164903496223" name="catchClause" index="TEbGg" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1164903280175" name="jetbrains.mps.baseLanguage.structure.CatchClause" flags="nn" index="TDmWw">
+        <child id="1164903359218" name="catchBody" index="TDEfX" />
+        <child id="1164903359217" name="throwable" index="TDEfY" />
+      </concept>
+      <concept id="1070462154015" name="jetbrains.mps.baseLanguage.structure.StaticFieldDeclaration" flags="ig" index="Wx3nA">
+        <property id="6468716278899126575" name="isVolatile" index="2dlcS1" />
+        <property id="6468716278899125786" name="isTransient" index="2dld4O" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
+        <reference id="1144433194310" name="classConcept" index="1Pybhc" />
+      </concept>
+      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
+        <child id="1081256993305" name="classType" index="2ZW6by" />
+        <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
+      </concept>
+      <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
+        <reference id="1144433057691" name="classifier" index="1PxDUh" />
+      </concept>
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <property id="1176718929932" name="isFinal" index="3TUv4t" />
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271177708" name="jetbrains.mps.baseLanguage.structure.StringType" flags="in" index="17QB3L" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <property id="4276006055363816570" name="isSynchronized" index="od$2w" />
+        <property id="1181808852946" name="isFinal" index="DiZV1" />
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1212685548494" name="jetbrains.mps.baseLanguage.structure.ClassCreator" flags="nn" index="1pGfFk" />
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="7812454656619025416" name="jetbrains.mps.baseLanguage.structure.MethodDeclaration" flags="ng" index="1rXfSm">
+        <property id="8355037393041754995" name="isNative" index="2aFKle" />
+      </concept>
+      <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
+        <reference id="1107535924139" name="classifier" index="3uigEE" />
+      </concept>
+      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
+        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
+        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
+      </concept>
+      <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="6329021646629104957" name="jetbrains.mps.baseLanguage.structure.TextCommentPart" flags="nn" index="3SKdUq">
+        <property id="6329021646629104958" name="text" index="3SKdUp" />
+      </concept>
+      <concept id="6329021646629104954" name="jetbrains.mps.baseLanguage.structure.SingleLineComment" flags="nn" index="3SKdUt">
+        <child id="6329021646629175155" name="commentPart" index="3SKWNk" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+      <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
+      <concept id="1080120340718" name="jetbrains.mps.baseLanguage.structure.AndExpression" flags="nn" index="1Wc70l" />
+    </language>
+    <language id="47f075a6-558e-4640-a606-7ce0236c8023" name="com.mbeddr.mpsutil.interpreter">
+      <concept id="7019451652830285943" name="com.mbeddr.mpsutil.interpreter.structure.ApplicableLanguage" flags="ng" index="d$4Dx">
+        <child id="7019451652831666945" name="language" index="cpn$n" />
+      </concept>
+      <concept id="5293529713177831489" name="com.mbeddr.mpsutil.interpreter.structure.NodeExpression" flags="ng" index="oxGPV" />
+      <concept id="8615074351687299818" name="com.mbeddr.mpsutil.interpreter.structure.Interpreter" flags="ng" index="qq9qg">
+        <property id="8426159527444241399" name="category" index="UYu25" />
+        <child id="7019451652830298090" name="applicableLanguages" index="d$6nW" />
+        <child id="8615074351687302157" name="evaluators" index="qq9xR" />
+      </concept>
+      <concept id="8615074351687301435" name="com.mbeddr.mpsutil.interpreter.structure.ConceptEvaluator" flags="ng" index="qq9P1">
+        <reference id="8615074351687302216" name="concept" index="qq9wM" />
+      </concept>
+      <concept id="5293529713180742448" name="com.mbeddr.mpsutil.interpreter.structure.InterpretConstraintExpression" flags="ng" index="rqRoa" />
+      <concept id="3406009787378976616" name="com.mbeddr.mpsutil.interpreter.structure.EnvExpression" flags="ng" index="TvHiN" />
+      <concept id="5712773029518214110" name="com.mbeddr.mpsutil.interpreter.structure.ConceptEvaluatorBody" flags="ng" index="3dA_Gj">
+        <child id="5934114435582613364" name="body" index="3vcmbn" />
+      </concept>
+      <concept id="5934114435583058812" name="com.mbeddr.mpsutil.interpreter.structure.AbstractEvaluator" flags="ng" index="3va1rv">
+        <property id="8845772667389641968" name="cacheValues" index="2TnfIJ" />
+        <child id="5934114435584084790" name="evaluator" index="3vQZUl" />
+      </concept>
+      <concept id="5934114435582125873" name="com.mbeddr.mpsutil.interpreter.structure.ConceptEvaluatorInline" flags="ng" index="3vetai">
+        <child id="5934114435582660673" name="expression" index="3vdyny" />
+      </concept>
+      <concept id="8511326569641917307" name="com.mbeddr.mpsutil.interpreter.structure.AbstractConstraintRecursionExpression" flags="ng" index="3SLZkg">
+        <reference id="5293529713180742449" name="child" index="rqRob" />
+      </concept>
+    </language>
+    <language id="760a0a8c-eabb-4521-8bfd-65db761a9ba3" name="jetbrains.mps.baseLanguage.logging">
+      <concept id="6332851714983831325" name="jetbrains.mps.baseLanguage.logging.structure.MsgStatement" flags="ng" index="2xdQw9">
+        <property id="6332851714983843871" name="severity" index="2xdLsb" />
+        <child id="5721587534047265374" name="message" index="9lYJi" />
+        <child id="5721587534047265375" name="throwable" index="9lYJj" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="559557797393017698" name="jetbrains.mps.lang.smodel.structure.ModelReferenceExpression" flags="nn" index="BaHAS">
+        <property id="559557797393021807" name="stereotype" index="BaGAP" />
+        <property id="559557797393017702" name="name" index="BaHAW" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2" />
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="1197932370469" name="jetbrains.mps.baseLanguage.collections.structure.MapElement" flags="nn" index="3EllGN">
+        <child id="1197932505799" name="map" index="3ElQJh" />
+        <child id="1197932525128" name="key" index="3ElVtu" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="qq9qg" id="2Xv3T3_hD0Q">
+    <property role="TrG5h" value="MpsWorkshop" />
+    <property role="UYu25" value="mps-workshop" />
+    <node concept="d$4Dx" id="2Xv3T3_hD0R" role="d$6nW">
+      <node concept="BaHAS" id="2Xv3T3_hD0S" role="cpn$n">
+        <property role="BaHAW" value="mps.workshop.lang.structure" />
+        <property role="BaGAP" value="" />
+      </node>
+    </node>
+    <node concept="qq9P1" id="2Xv3T3_hIja" role="qq9xR">
+      <property role="2TnfIJ" value="true" />
+      <ref role="qq9wM" to="85g0:Juyp1w2Ti3" resolve="NumberLiteral" />
+      <node concept="3vetai" id="2Xv3T3_hIjk" role="3vQZUl">
+        <node concept="2ShNRf" id="2Xv3T3_hIjy" role="3vdyny">
+          <node concept="1pGfFk" id="2Xv3T3_hL20" role="2ShVmc">
+            <ref role="37wK5l" to="xlxw:~BigInteger.&lt;init&gt;(java.lang.String)" resolve="BigInteger" />
+            <node concept="2OqwBi" id="2Xv3T3_hLha" role="37wK5m">
+              <node concept="oxGPV" id="2Xv3T3_hL4X" role="2Oq$k0" />
+              <node concept="3TrcHB" id="2Xv3T3_hLvc" role="2OqNvi">
+                <ref role="3TsBF5" to="85g0:Juyp1w2Ti7" resolve="value" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="qq9P1" id="2Xv3T3_hL$r" role="qq9xR">
+      <property role="2TnfIJ" value="true" />
+      <ref role="qq9wM" to="85g0:Juyp1w2Jtg" resolve="VariableDeclaration" />
+      <node concept="3dA_Gj" id="2Xv3T3_ivHQ" role="3vQZUl">
+        <node concept="9aQIb" id="2Xv3T3_ivHS" role="3vcmbn">
+          <node concept="3clFbS" id="2Xv3T3_ivHU" role="9aQI4">
+            <node concept="3cpWs8" id="2Xv3T3_ivKk" role="3cqZAp">
+              <node concept="3cpWsn" id="2Xv3T3_ivKl" role="3cpWs9">
+                <property role="TrG5h" value="init" />
+                <node concept="3uibUv" id="2Xv3T3_ivKj" role="1tU5fm">
+                  <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                </node>
+                <node concept="rqRoa" id="2Xv3T3_ivKm" role="33vP2m">
+                  <ref role="rqRob" to="85g0:Juyp1w2LZ6" resolve="initializer" />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbF" id="2Xv3T3_ivI7" role="3cqZAp">
+              <node concept="37vLTI" id="2Xv3T3_hOSv" role="3clFbG">
+                <node concept="37vLTw" id="2Xv3T3_ivKn" role="37vLTx">
+                  <ref role="3cqZAo" node="2Xv3T3_ivKl" resolve="init" />
+                </node>
+                <node concept="3EllGN" id="2Xv3T3_hO$z" role="37vLTJ">
+                  <node concept="oxGPV" id="2Xv3T3_hO_P" role="3ElVtu" />
+                  <node concept="TvHiN" id="2Xv3T3_hL$X" role="3ElQJh" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="2Xv3T3_ivU5" role="3cqZAp">
+              <node concept="37vLTw" id="2Xv3T3_ivWw" role="3cqZAk">
+                <ref role="3cqZAo" node="2Xv3T3_ivKl" resolve="init" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="qq9P1" id="2Xv3T3_hP4l" role="qq9xR">
+      <property role="2TnfIJ" value="true" />
+      <ref role="qq9wM" to="85g0:Juyp1w4oKW" resolve="PlusExpression" />
+      <node concept="3dA_Gj" id="2Xv3T3_hP4K" role="3vQZUl">
+        <node concept="9aQIb" id="2Xv3T3_hP4M" role="3vcmbn">
+          <node concept="3clFbS" id="2Xv3T3_hP4O" role="9aQI4">
+            <node concept="3cpWs8" id="2Xv3T3_hPb9" role="3cqZAp">
+              <node concept="3cpWsn" id="2Xv3T3_hPba" role="3cpWs9">
+                <property role="TrG5h" value="left" />
+                <node concept="3uibUv" id="2Xv3T3_hPb8" role="1tU5fm">
+                  <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                </node>
+                <node concept="rqRoa" id="2Xv3T3_hPbb" role="33vP2m">
+                  <ref role="rqRob" to="85g0:Juyp1w3DPT" resolve="left" />
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs8" id="2Xv3T3_hPhS" role="3cqZAp">
+              <node concept="3cpWsn" id="2Xv3T3_hPhT" role="3cpWs9">
+                <property role="TrG5h" value="right" />
+                <node concept="3uibUv" id="2Xv3T3_hPhR" role="1tU5fm">
+                  <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                </node>
+                <node concept="rqRoa" id="2Xv3T3_hPhU" role="33vP2m">
+                  <ref role="rqRob" to="85g0:Juyp1w3DPW" resolve="right" />
+                </node>
+              </node>
+            </node>
+            <node concept="3SKdUt" id="2Xv3T3_hQCA" role="3cqZAp">
+              <node concept="3SKdUq" id="2Xv3T3_hQCC" role="3SKWNk">
+                <property role="3SKdUp" value="Think about using type mapping and type guards to get rid of this" />
+              </node>
+            </node>
+            <node concept="3clFbJ" id="2Xv3T3_hPm3" role="3cqZAp">
+              <node concept="3clFbS" id="2Xv3T3_hPm5" role="3clFbx">
+                <node concept="3cpWs6" id="2Xv3T3_hSia" role="3cqZAp">
+                  <node concept="2OqwBi" id="2Xv3T3_hSic" role="3cqZAk">
+                    <node concept="1eOMI4" id="2Xv3T3_hSid" role="2Oq$k0">
+                      <node concept="10QFUN" id="2Xv3T3_hSie" role="1eOMHV">
+                        <node concept="37vLTw" id="2Xv3T3_hSif" role="10QFUP">
+                          <ref role="3cqZAo" node="2Xv3T3_hPba" resolve="left" />
+                        </node>
+                        <node concept="3uibUv" id="2Xv3T3_hSig" role="10QFUM">
+                          <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="2Xv3T3_hSih" role="2OqNvi">
+                      <ref role="37wK5l" to="xlxw:~BigInteger.add(java.math.BigInteger):java.math.BigInteger" resolve="add" />
+                      <node concept="10QFUN" id="2Xv3T3_hSii" role="37wK5m">
+                        <node concept="37vLTw" id="2Xv3T3_hSij" role="10QFUP">
+                          <ref role="3cqZAo" node="2Xv3T3_hPhT" resolve="right" />
+                        </node>
+                        <node concept="3uibUv" id="2Xv3T3_hSik" role="10QFUM">
+                          <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="1Wc70l" id="2Xv3T3_hQh0" role="3clFbw">
+                <node concept="2ZW3vV" id="2Xv3T3_hQsC" role="3uHU7w">
+                  <node concept="3uibUv" id="2Xv3T3_hQ$f" role="2ZW6by">
+                    <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
+                  </node>
+                  <node concept="37vLTw" id="2Xv3T3_hQhE" role="2ZW6bz">
+                    <ref role="3cqZAo" node="2Xv3T3_hPhT" resolve="right" />
+                  </node>
+                </node>
+                <node concept="2ZW3vV" id="2Xv3T3_hP$y" role="3uHU7B">
+                  <node concept="3uibUv" id="2Xv3T3_hPFT" role="2ZW6by">
+                    <ref role="3uigEE" to="xlxw:~BigInteger" resolve="BigInteger" />
+                  </node>
+                  <node concept="37vLTw" id="2Xv3T3_hPmC" role="2ZW6bz">
+                    <ref role="3cqZAo" node="2Xv3T3_hPba" resolve="left" />
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3cpWs6" id="2Xv3T3_hQHu" role="3cqZAp">
+              <node concept="10Nm6u" id="2Xv3T3_hQIz" role="3cqZAk" />
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="qq9P1" id="2Xv3T3_ix1h" role="qq9xR">
+      <property role="2TnfIJ" value="true" />
+      <ref role="qq9wM" to="85g0:Juyp1w4oLE" resolve="MinusExpression" />
+      <node concept="3dA_Gj" id="2Xv3T3_ix33" role="3vQZUl">
+        <node concept="9aQIb" id="2Xv3T3_ix35" role="3vcmbn">
+          <node concept="3clFbS" id="2Xv3T3_ix37" role="9aQI4">
+            <node concept="3cpWs6" id="2Xv3T3_ix6f" role="3cqZAp">
+              <node concept="10M0yZ" id="2Xv3T3_ixsi" role="3cqZAk">
+                <ref role="3cqZAo" to="xlxw:~BigInteger.ZERO" resolve="ZERO" />
+                <ref role="1PxDUh" to="xlxw:~BigInteger" resolve="BigInteger" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="qq9P1" id="2Xv3T3_ixj$" role="qq9xR">
+      <property role="2TnfIJ" value="true" />
+      <ref role="qq9wM" to="85g0:Juyp1w4oUO" resolve="MulExpression" />
+      <node concept="3dA_Gj" id="2Xv3T3_ixlw" role="3vQZUl">
+        <node concept="9aQIb" id="2Xv3T3_ixly" role="3vcmbn">
+          <node concept="3clFbS" id="2Xv3T3_ixl$" role="9aQI4">
+            <node concept="3cpWs6" id="2Xv3T3_ixrB" role="3cqZAp">
+              <node concept="10M0yZ" id="2Xv3T3_ixrW" role="3cqZAk">
+                <ref role="3cqZAo" to="xlxw:~BigInteger.ZERO" resolve="ZERO" />
+                <ref role="1PxDUh" to="xlxw:~BigInteger" resolve="BigInteger" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="qq9P1" id="2Xv3T3_ixuq" role="qq9xR">
+      <property role="2TnfIJ" value="true" />
+      <ref role="qq9wM" to="85g0:Juyp1w4pia" resolve="DivExpression" />
+      <node concept="3dA_Gj" id="2Xv3T3_ixww" role="3vQZUl">
+        <node concept="9aQIb" id="2Xv3T3_ixwy" role="3vcmbn">
+          <node concept="3clFbS" id="2Xv3T3_ixw$" role="9aQI4">
+            <node concept="3cpWs6" id="2Xv3T3_ixzG" role="3cqZAp">
+              <node concept="10M0yZ" id="2Xv3T3_ixzZ" role="3cqZAk">
+                <ref role="3cqZAo" to="xlxw:~BigInteger.ZERO" resolve="ZERO" />
+                <ref role="1PxDUh" to="xlxw:~BigInteger" resolve="BigInteger" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="qq9P1" id="2Xv3T3_ixAh" role="qq9xR">
+      <property role="2TnfIJ" value="true" />
+      <ref role="qq9wM" to="85g0:Juyp1w4RIQ" resolve="ParensExpression" />
+      <node concept="3dA_Gj" id="2Xv3T3_ixCx" role="3vQZUl">
+        <node concept="9aQIb" id="2Xv3T3_ixCz" role="3vcmbn">
+          <node concept="3clFbS" id="2Xv3T3_ixC_" role="9aQI4">
+            <node concept="3cpWs6" id="2Xv3T3_ixFH" role="3cqZAp">
+              <node concept="10M0yZ" id="2Xv3T3_ixG2" role="3cqZAk">
+                <ref role="3cqZAo" to="xlxw:~BigInteger.ZERO" resolve="ZERO" />
+                <ref role="1PxDUh" to="xlxw:~BigInteger" resolve="BigInteger" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+  </node>
+  <node concept="312cEu" id="2Xv3T3_hTLQ">
+    <property role="TrG5h" value="EvalHelper" />
+    <node concept="2tJIrI" id="2Xv3T3_hUfo" role="jymVt" />
+    <node concept="Wx3nA" id="2Xv3T3_hUsm" role="jymVt">
+      <property role="2dlcS1" value="false" />
+      <property role="2dld4O" value="false" />
+      <property role="TrG5h" value="helper" />
+      <property role="3TUv4t" value="false" />
+      <node concept="3Tm6S6" id="2Xv3T3_hUj9" role="1B3o_S" />
+      <node concept="3uibUv" id="2Xv3T3_hUvA" role="1tU5fm">
+        <ref role="3uigEE" to="2ahs:50LzNoSxDO3" resolve="InterpreterEvaluationHelper" />
+      </node>
+      <node concept="2ShNRf" id="2Xv3T3_hUwt" role="33vP2m">
+        <node concept="1pGfFk" id="2Xv3T3_hUwf" role="2ShVmc">
+          <ref role="37wK5l" to="2ahs:50LzNoSxJpU" resolve="InterpreterEvaluationHelper" />
+          <node concept="Xl_RD" id="2Xv3T3_hUwZ" role="37wK5m">
+            <property role="Xl_RC" value="mps-workshop" />
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="2Xv3T3_hUfD" role="jymVt" />
+    <node concept="2YIFZL" id="2Xv3T3_hTVq" role="jymVt">
+      <property role="TrG5h" value="eval" />
+      <property role="od$2w" value="false" />
+      <property role="DiZV1" value="false" />
+      <property role="2aFKle" value="false" />
+      <node concept="3clFbS" id="2Xv3T3_hTVt" role="3clF47">
+        <node concept="SfApY" id="2Xv3T3_hUCL" role="3cqZAp">
+          <node concept="3clFbS" id="2Xv3T3_hUCM" role="SfCbr">
+            <node concept="3cpWs8" id="2Xv3T3_hV8V" role="3cqZAp">
+              <node concept="3cpWsn" id="2Xv3T3_hV8W" role="3cpWs9">
+                <property role="TrG5h" value="result" />
+                <node concept="3uibUv" id="2Xv3T3_hV8P" role="1tU5fm">
+                  <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+                </node>
+                <node concept="2OqwBi" id="2Xv3T3_hV8X" role="33vP2m">
+                  <node concept="37vLTw" id="2Xv3T3_hV8Y" role="2Oq$k0">
+                    <ref role="3cqZAo" node="2Xv3T3_hUsm" resolve="helper" />
+                  </node>
+                  <node concept="liA8E" id="2Xv3T3_hV8Z" role="2OqNvi">
+                    <ref role="37wK5l" to="2ahs:50LzNoSxJob" resolve="evaluate" />
+                    <node concept="37vLTw" id="2Xv3T3_hV90" role="37wK5m">
+                      <ref role="3cqZAo" node="2Xv3T3_hU1B" resolve="n" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="2Xv3T3_hVpt" role="3cqZAp">
+              <node concept="3clFbS" id="2Xv3T3_hVpv" role="3clFbx">
+                <node concept="3cpWs6" id="2Xv3T3_hWg3" role="3cqZAp">
+                  <node concept="2YIFZM" id="2Xv3T3_hWim" role="3cqZAk">
+                    <ref role="37wK5l" to="wyt6:~String.valueOf(java.lang.Object):java.lang.String" resolve="valueOf" />
+                    <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
+                    <node concept="37vLTw" id="2Xv3T3_hWqn" role="37wK5m">
+                      <ref role="3cqZAo" node="2Xv3T3_hV8W" resolve="result" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3y3z36" id="2Xv3T3_hVzQ" role="3clFbw">
+                <node concept="10Nm6u" id="2Xv3T3_hVAw" role="3uHU7w" />
+                <node concept="37vLTw" id="2Xv3T3_hVtd" role="3uHU7B">
+                  <ref role="3cqZAo" node="2Xv3T3_hV8W" resolve="result" />
+                </node>
+              </node>
+              <node concept="9aQIb" id="2Xv3T3_hVG2" role="9aQIa">
+                <node concept="3clFbS" id="2Xv3T3_hVG3" role="9aQI4">
+                  <node concept="3cpWs6" id="2Xv3T3_hVLB" role="3cqZAp">
+                    <node concept="Xl_RD" id="2Xv3T3_hVR$" role="3cqZAk">
+                      <property role="Xl_RC" value="&lt;null&gt;" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="TDmWw" id="2Xv3T3_hUCN" role="TEbGg">
+            <node concept="3cpWsn" id="2Xv3T3_hUCO" role="TDEfY">
+              <property role="TrG5h" value="e" />
+              <node concept="3uibUv" id="2Xv3T3_hUJ4" role="1tU5fm">
+                <ref role="3uigEE" to="wyt6:~Exception" resolve="Exception" />
+              </node>
+            </node>
+            <node concept="3clFbS" id="2Xv3T3_hUCQ" role="TDEfX">
+              <node concept="2xdQw9" id="2Xv3T3_hXF4" role="3cqZAp">
+                <property role="2xdLsb" value="error" />
+                <node concept="Xl_RD" id="2Xv3T3_hXF6" role="9lYJi">
+                  <property role="Xl_RC" value="Interpreter failed" />
+                </node>
+                <node concept="37vLTw" id="2Xv3T3_hXF8" role="9lYJj">
+                  <ref role="3cqZAo" node="2Xv3T3_hUCO" resolve="e" />
+                </node>
+              </node>
+              <node concept="3cpWs6" id="2Xv3T3_hW_O" role="3cqZAp">
+                <node concept="Xl_RD" id="2Xv3T3_hWGw" role="3cqZAk">
+                  <property role="Xl_RC" value="&lt;error&gt;" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="2Xv3T3_hTPd" role="1B3o_S" />
+      <node concept="17QB3L" id="2Xv3T3_hTVj" role="3clF45" />
+      <node concept="37vLTG" id="2Xv3T3_hU1B" role="3clF46">
+        <property role="TrG5h" value="n" />
+        <node concept="3Tqbb2" id="2Xv3T3_hU1A" role="1tU5fm" />
+      </node>
+    </node>
+    <node concept="3Tm1VV" id="2Xv3T3_hTLR" role="1B3o_S" />
+  </node>
+</model>
+

--- a/mps-workshop-2-itemis/solutions/mps.workshop.interpreter/mps.workshop.interpreter.msd
+++ b/mps-workshop-2-itemis/solutions/mps.workshop.interpreter/mps.workshop.interpreter.msd
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="mps.workshop.interpreter" uuid="85da2157-b28c-4c6c-ac6d-66f42719ba01" moduleVersion="0" pluginKind="PLUGIN_OTHER" compileInMPS="true">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <sourcePath />
+  <dependencies>
+    <dependency reexport="false">c9c683f9-1916-4ea4-bc6e-ec5b2a10659d(mps.workshop.lang)</dependency>
+    <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
+    <dependency reexport="false">735f86bc-17fb-4d1c-a664-82c2b8e8a34e(com.mbeddr.mpsutil.interpreter.rt)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:47f075a6-558e-4640-a606-7ce0236c8023:com.mbeddr.mpsutil.interpreter" version="0" />
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="5" />
+    <language slang="l:443f4c36-fcf5-4eb6-9500-8d06ed259e3e:jetbrains.mps.baseLanguage.classifiers" version="0" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="0" />
+    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <language slang="l:760a0a8c-eabb-4521-8bfd-65db761a9ba3:jetbrains.mps.baseLanguage.logging" version="0" />
+    <language slang="l:a247e09e-2435-45ba-b8d2-07e93feba96a:jetbrains.mps.baseLanguage.tuples" version="0" />
+    <language slang="l:fe9d76d7-5809-45c9-ae28-a40915b4d6ff:jetbrains.mps.lang.checkedName" version="0" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="1" />
+    <language slang="l:28f9e497-3b42-4291-aeba-0a1039153ab1:jetbrains.mps.lang.plugin" version="2" />
+    <language slang="l:ef7bf5ac-d06c-4342-b11d-e42104eb9343:jetbrains.mps.lang.plugin.standalone" version="0" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="0" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="8" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="735f86bc-17fb-4d1c-a664-82c2b8e8a34e(com.mbeddr.mpsutil.interpreter.rt)" version="0" />
+    <module reference="726886d1-ef90-4249-a08f-1e3ec23a7113(com.mbeddr.mpsutil.traceExplorer)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
+    <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
+    <module reference="85da2157-b28c-4c6c-ac6d-66f42719ba01(mps.workshop.interpreter)" version="0" />
+    <module reference="c9c683f9-1916-4ea4-bc6e-ec5b2a10659d(mps.workshop.lang)" version="0" />
+  </dependencyVersions>
+</solution>
+

--- a/mps-workshop-2-itemis/solutions/mps.workshop.runtime/models/plugin.mps
+++ b/mps-workshop-2-itemis/solutions/mps.workshop.runtime/models/plugin.mps
@@ -1,0 +1,375 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:b22c5d7d-a0df-49ab-afea-c323c4910fc1(mps.workshop.runtime.plugin)">
+  <persistence version="9" />
+  <languages>
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="5" />
+    <use id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel" version="8" />
+    <use id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation" version="0" />
+    <use id="7a5dda62-9140-4668-ab76-d5ed1746f2b2" name="jetbrains.mps.lang.typesystem" version="1" />
+  </languages>
+  <imports>
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
+    <import index="85g0" ref="r:3255fe94-9102-4828-b2d9-432a6ecad106(mps.workshop.lang.structure)" />
+    <import index="tpck" ref="r:00000000-0000-4000-0000-011c89590288(jetbrains.mps.lang.core.structure)" implicit="true" />
+  </imports>
+  <registry>
+    <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
+        <child id="1068498886297" name="rValue" index="37vLTx" />
+        <child id="1068498886295" name="lValue" index="37vLTJ" />
+      </concept>
+      <concept id="1465982738277781862" name="jetbrains.mps.baseLanguage.structure.PlaceholderMember" flags="ng" index="2tJIrI" />
+      <concept id="1154032098014" name="jetbrains.mps.baseLanguage.structure.AbstractLoopStatement" flags="nn" index="2LF5Ji">
+        <child id="1154032183016" name="body" index="2LFqv$" />
+      </concept>
+      <concept id="1197027756228" name="jetbrains.mps.baseLanguage.structure.DotExpression" flags="nn" index="2OqwBi">
+        <child id="1197027771414" name="operand" index="2Oq$k0" />
+        <child id="1197027833540" name="operation" index="2OqNvi" />
+      </concept>
+      <concept id="1145552977093" name="jetbrains.mps.baseLanguage.structure.GenericNewExpression" flags="nn" index="2ShNRf">
+        <child id="1145553007750" name="creator" index="2ShVmc" />
+      </concept>
+      <concept id="1070475926800" name="jetbrains.mps.baseLanguage.structure.StringLiteral" flags="nn" index="Xl_RD">
+        <property id="1070475926801" name="value" index="Xl_RC" />
+      </concept>
+      <concept id="1081236700938" name="jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" flags="ig" index="2YIFZL" />
+      <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu" />
+      <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
+        <property id="1176718929932" name="isFinal" index="3TUv4t" />
+        <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
+        <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
+      </concept>
+      <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
+      <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
+        <child id="5680397130376446158" name="type" index="1tU5fm" />
+      </concept>
+      <concept id="1068580123132" name="jetbrains.mps.baseLanguage.structure.BaseMethodDeclaration" flags="ng" index="3clF44">
+        <property id="4276006055363816570" name="isSynchronized" index="od$2w" />
+        <property id="1181808852946" name="isFinal" index="DiZV1" />
+        <child id="1068580123133" name="returnType" index="3clF45" />
+        <child id="1068580123134" name="parameter" index="3clF46" />
+        <child id="1068580123135" name="body" index="3clF47" />
+      </concept>
+      <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
+        <child id="1068580123156" name="expression" index="3clFbG" />
+      </concept>
+      <concept id="1068580123157" name="jetbrains.mps.baseLanguage.structure.Statement" flags="nn" index="3clFbH" />
+      <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
+        <child id="1068581517665" name="statement" index="3cqZAp" />
+      </concept>
+      <concept id="1068581242878" name="jetbrains.mps.baseLanguage.structure.ReturnStatement" flags="nn" index="3cpWs6">
+        <child id="1068581517676" name="expression" index="3cqZAk" />
+      </concept>
+      <concept id="1068581242864" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" flags="nn" index="3cpWs8">
+        <child id="1068581242865" name="localVariableDeclaration" index="3cpWs9" />
+      </concept>
+      <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
+      <concept id="1204053956946" name="jetbrains.mps.baseLanguage.structure.IMethodCall" flags="ng" index="1ndlxa">
+        <reference id="1068499141037" name="baseMethodDeclaration" index="37wK5l" />
+        <child id="1068499141038" name="actualArgument" index="37wK5m" />
+      </concept>
+      <concept id="1107461130800" name="jetbrains.mps.baseLanguage.structure.Classifier" flags="ng" index="3pOWGL">
+        <child id="5375687026011219971" name="member" index="jymVt" unordered="true" />
+      </concept>
+      <concept id="7812454656619025416" name="jetbrains.mps.baseLanguage.structure.MethodDeclaration" flags="ng" index="1rXfSm">
+        <property id="8355037393041754995" name="isNative" index="2aFKle" />
+      </concept>
+      <concept id="7812454656619025412" name="jetbrains.mps.baseLanguage.structure.LocalMethodCall" flags="nn" index="1rXfSq" />
+      <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
+        <child id="1178549979242" name="visibility" index="1B3o_S" />
+      </concept>
+      <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
+    </language>
+    <language id="3a13115c-633c-4c5c-bbcc-75c4219e9555" name="jetbrains.mps.lang.quotation">
+      <concept id="5455284157994012186" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitLink" flags="ng" index="2pIpSj">
+        <reference id="5455284157994012188" name="link" index="2pIpSl" />
+      </concept>
+      <concept id="5455284157993911077" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitProperty" flags="ng" index="2pJxcG">
+        <reference id="5455284157993911078" name="property" index="2pJxcJ" />
+      </concept>
+      <concept id="5455284157993911097" name="jetbrains.mps.lang.quotation.structure.NodeBuilderInitPart" flags="ng" index="2pJxcK">
+        <child id="5455284157993911094" name="expression" index="2pJxcZ" />
+      </concept>
+      <concept id="5455284157993863837" name="jetbrains.mps.lang.quotation.structure.NodeBuilder" flags="nn" index="2pJPEk">
+        <child id="5455284157993863838" name="quotedNode" index="2pJPEn" />
+      </concept>
+      <concept id="5455284157993863840" name="jetbrains.mps.lang.quotation.structure.NodeBuilderNode" flags="nn" index="2pJPED">
+        <reference id="5455284157993910961" name="concept" index="2pJxaS" />
+        <child id="5455284157993911099" name="values" index="2pJxcM" />
+      </concept>
+      <concept id="8182547171709738802" name="jetbrains.mps.lang.quotation.structure.NodeBuilderList" flags="nn" index="36be1Y">
+        <child id="8182547171709738803" name="nodes" index="36be1Z" />
+      </concept>
+    </language>
+    <language id="7866978e-a0f0-4cc7-81bc-4d213d9375e1" name="jetbrains.mps.lang.smodel">
+      <concept id="1180636770613" name="jetbrains.mps.lang.smodel.structure.SNodeCreator" flags="nn" index="3zrR0B">
+        <child id="1180636770616" name="createdType" index="3zrR0E" />
+      </concept>
+      <concept id="1138055754698" name="jetbrains.mps.lang.smodel.structure.SNodeType" flags="in" index="3Tqbb2">
+        <reference id="1138405853777" name="concept" index="ehGHo" />
+      </concept>
+      <concept id="1138056022639" name="jetbrains.mps.lang.smodel.structure.SPropertyAccess" flags="nn" index="3TrcHB">
+        <reference id="1138056395725" name="property" index="3TsBF5" />
+      </concept>
+      <concept id="1138056143562" name="jetbrains.mps.lang.smodel.structure.SLinkAccess" flags="nn" index="3TrEf2">
+        <reference id="1138056516764" name="link" index="3Tt5mk" />
+      </concept>
+      <concept id="1138056282393" name="jetbrains.mps.lang.smodel.structure.SLinkListAccess" flags="nn" index="3Tsc0h">
+        <reference id="1138056546658" name="link" index="3TtcxE" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+    <language id="83888646-71ce-4f1c-9c53-c54016f6ad4f" name="jetbrains.mps.baseLanguage.collections">
+      <concept id="540871147943773365" name="jetbrains.mps.baseLanguage.collections.structure.SingleArgumentSequenceOperation" flags="nn" index="25WWJ4">
+        <child id="540871147943773366" name="argument" index="25WWJ7" />
+      </concept>
+      <concept id="1153943597977" name="jetbrains.mps.baseLanguage.collections.structure.ForEachStatement" flags="nn" index="2Gpval">
+        <child id="1153944400369" name="variable" index="2Gsz3X" />
+        <child id="1153944424730" name="inputSequence" index="2GsD0m" />
+      </concept>
+      <concept id="1153944193378" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariable" flags="nr" index="2GrKxI" />
+      <concept id="1153944233411" name="jetbrains.mps.baseLanguage.collections.structure.ForEachVariableReference" flags="nn" index="2GrUjf">
+        <reference id="1153944258490" name="variable" index="2Gs0qQ" />
+      </concept>
+      <concept id="1160612413312" name="jetbrains.mps.baseLanguage.collections.structure.AddElementOperation" flags="nn" index="TSZUe" />
+    </language>
+  </registry>
+  <node concept="312cEu" id="4jnZTahfvSp">
+    <property role="TrG5h" value="Compiler" />
+    <node concept="2tJIrI" id="4jnZTahfvSN" role="jymVt" />
+    <node concept="2YIFZL" id="4jnZTahjrwC" role="jymVt">
+      <property role="TrG5h" value="compileWorksheet" />
+      <property role="od$2w" value="false" />
+      <property role="DiZV1" value="false" />
+      <property role="2aFKle" value="false" />
+      <node concept="3clFbS" id="4jnZTahjrwF" role="3clF47">
+        <node concept="3cpWs8" id="4jnZTahjrFH" role="3cqZAp">
+          <node concept="3cpWsn" id="4jnZTahjrFK" role="3cpWs9">
+            <property role="TrG5h" value="clazz" />
+            <node concept="3Tqbb2" id="4jnZTahjrFF" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+            </node>
+            <node concept="2ShNRf" id="4jnZTahjrHu" role="33vP2m">
+              <node concept="3zrR0B" id="4jnZTahjrGP" role="2ShVmc">
+                <node concept="3Tqbb2" id="4jnZTahjrGQ" role="3zrR0E">
+                  <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="4jnZTahjrIz" role="3cqZAp">
+          <node concept="37vLTI" id="4jnZTahjtcw" role="3clFbG">
+            <node concept="Xl_RD" id="4jnZTahjth6" role="37vLTx">
+              <property role="Xl_RC" value="Main" />
+            </node>
+            <node concept="2OqwBi" id="4jnZTahjrYn" role="37vLTJ">
+              <node concept="37vLTw" id="4jnZTahjrIx" role="2Oq$k0">
+                <ref role="3cqZAo" node="4jnZTahjrFK" resolve="clazz" />
+              </node>
+              <node concept="3TrcHB" id="4jnZTahjsqJ" role="2OqNvi">
+                <ref role="3TsBF5" to="tpck:h0TrG11" resolve="name" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4jnZTahjtzo" role="3cqZAp" />
+        <node concept="3cpWs8" id="4jnZTahjzEG" role="3cqZAp">
+          <node concept="3cpWsn" id="4jnZTahjzEJ" role="3cpWs9">
+            <property role="TrG5h" value="method" />
+            <property role="3TUv4t" value="false" />
+            <node concept="3Tqbb2" id="4jnZTahjzEE" role="1tU5fm">
+              <ref role="ehGHo" to="tpee:fIYIFWa" resolve="StaticMethodDeclaration" />
+            </node>
+            <node concept="2pJPEk" id="4jnZTahjL2T" role="33vP2m">
+              <node concept="2pJPED" id="4jnZTahjLsk" role="2pJPEn">
+                <ref role="2pJxaS" to="tpee:fIYIFWa" resolve="StaticMethodDeclaration" />
+                <node concept="2pJxcG" id="4jnZTahjM88" role="2pJxcM">
+                  <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                  <node concept="Xl_RD" id="4jnZTahjMup" role="2pJxcZ">
+                    <property role="Xl_RC" value="main" />
+                  </node>
+                </node>
+                <node concept="2pIpSj" id="4jnZTahjMOR" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:fzclF7X" resolve="returnType" />
+                  <node concept="2pJPED" id="4jnZTahjNaT" role="2pJxcZ">
+                    <ref role="2pJxaS" to="tpee:fzcqZ_H" resolve="VoidType" />
+                  </node>
+                </node>
+                <node concept="2pIpSj" id="4jnZTahjNzh" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:fzclF7Y" resolve="parameter" />
+                  <node concept="36be1Y" id="4jnZTahjNTw" role="2pJxcZ">
+                    <node concept="2pJPED" id="4jnZTahjNUb" role="36be1Z">
+                      <ref role="2pJxaS" to="tpee:fz7vLUk" resolve="ParameterDeclaration" />
+                      <node concept="2pJxcG" id="4jnZTahjNVI" role="2pJxcM">
+                        <ref role="2pJxcJ" to="tpck:h0TrG11" resolve="name" />
+                        <node concept="Xl_RD" id="4jnZTahjNWV" role="2pJxcZ">
+                          <property role="Xl_RC" value="args" />
+                        </node>
+                      </node>
+                      <node concept="2pIpSj" id="4jnZTahjNYl" role="2pJxcM">
+                        <ref role="2pIpSl" to="tpee:4VkOLwjf83e" resolve="type" />
+                        <node concept="2pJPED" id="4jnZTahjNZj" role="2pJxcZ">
+                          <ref role="2pJxaS" to="tpee:f_0Q1BR" resolve="ArrayType" />
+                          <node concept="2pIpSj" id="4jnZTahjNZR" role="2pJxcM">
+                            <ref role="2pIpSl" to="tpee:f_0Q1BS" resolve="componentType" />
+                            <node concept="2pJPED" id="4jnZTahjO0h" role="2pJxcZ">
+                              <ref role="2pJxaS" to="tpee:hP7QB7G" resolve="StringType" />
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2pIpSj" id="4jnZTahjOoN" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:fzclF7Z" resolve="body" />
+                  <node concept="2pJPED" id="4jnZTahjOLj" role="2pJxcZ">
+                    <ref role="2pJxaS" to="tpee:fzclF80" resolve="StatementList" />
+                  </node>
+                </node>
+                <node concept="2pIpSj" id="4jnZTahlzeL" role="2pJxcM">
+                  <ref role="2pIpSl" to="tpee:h9B3oxE" resolve="visibility" />
+                  <node concept="2pJPED" id="4jnZTahlzNN" role="2pJxcZ">
+                    <ref role="2pJxaS" to="tpee:gFTm1ZL" resolve="PublicVisibility" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4jnZTahjRrI" role="3cqZAp" />
+        <node concept="2Gpval" id="4jnZTahjzUj" role="3cqZAp">
+          <node concept="2GrKxI" id="4jnZTahjzUl" role="2Gsz3X">
+            <property role="TrG5h" value="stmt" />
+          </node>
+          <node concept="2OqwBi" id="4jnZTahj$ao" role="2GsD0m">
+            <node concept="37vLTw" id="4jnZTahj$2f" role="2Oq$k0">
+              <ref role="3cqZAo" node="4jnZTahjrDS" resolve="input" />
+            </node>
+            <node concept="3Tsc0h" id="4jnZTahj$hY" role="2OqNvi">
+              <ref role="3TtcxE" to="85g0:Juyp1w2Jti" resolve="statements" />
+            </node>
+          </node>
+          <node concept="3clFbS" id="4jnZTahjzUp" role="2LFqv$">
+            <node concept="3clFbF" id="4jnZTahj$l3" role="3cqZAp">
+              <node concept="2OqwBi" id="4jnZTahjFrt" role="3clFbG">
+                <node concept="2OqwBi" id="4jnZTahjDd6" role="2Oq$k0">
+                  <node concept="2OqwBi" id="4jnZTahj$Cb" role="2Oq$k0">
+                    <node concept="37vLTw" id="4jnZTahj$l1" role="2Oq$k0">
+                      <ref role="3cqZAo" node="4jnZTahjzEJ" resolve="method" />
+                    </node>
+                    <node concept="3TrEf2" id="4jnZTahjCo9" role="2OqNvi">
+                      <ref role="3Tt5mk" to="tpee:fzclF7Z" resolve="body" />
+                    </node>
+                  </node>
+                  <node concept="3Tsc0h" id="4jnZTahjDzf" role="2OqNvi">
+                    <ref role="3TtcxE" to="tpee:fzcqZ_x" resolve="statement" />
+                  </node>
+                </node>
+                <node concept="TSZUe" id="4jnZTahjIOO" role="2OqNvi">
+                  <node concept="1rXfSq" id="4jnZTahjJ3O" role="25WWJ7">
+                    <ref role="37wK5l" node="4jnZTahfw1U" resolve="compileStatement" />
+                    <node concept="2GrUjf" id="4jnZTahjJic" role="37wK5m">
+                      <ref role="2Gs0qQ" node="4jnZTahjzUl" resolve="stmt" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="4jnZTahjR2I" role="3cqZAp" />
+        <node concept="3clFbF" id="4jnZTahju20" role="3cqZAp">
+          <node concept="2OqwBi" id="4jnZTahjwyl" role="3clFbG">
+            <node concept="2OqwBi" id="4jnZTahjuis" role="2Oq$k0">
+              <node concept="37vLTw" id="4jnZTahju1Y" role="2Oq$k0">
+                <ref role="3cqZAo" node="4jnZTahjrFK" resolve="clazz" />
+              </node>
+              <node concept="3Tsc0h" id="4jnZTahjuNI" role="2OqNvi">
+                <ref role="3TtcxE" to="tpee:4EqhHTp4Mw3" resolve="member" />
+              </node>
+            </node>
+            <node concept="TSZUe" id="4jnZTahjzad" role="2OqNvi">
+              <node concept="37vLTw" id="4jnZTahjSow" role="25WWJ7">
+                <ref role="3cqZAo" node="4jnZTahjzEJ" resolve="method" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="4jnZTahjtCU" role="3cqZAp">
+          <node concept="37vLTw" id="4jnZTahjtE8" role="3cqZAk">
+            <ref role="3cqZAo" node="4jnZTahjrFK" resolve="clazz" />
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4jnZTahjrne" role="1B3o_S" />
+      <node concept="3Tqbb2" id="4jnZTahjrwn" role="3clF45">
+        <ref role="ehGHo" to="tpee:fz12cDA" resolve="ClassConcept" />
+      </node>
+      <node concept="37vLTG" id="4jnZTahjrDS" role="3clF46">
+        <property role="TrG5h" value="input" />
+        <node concept="3Tqbb2" id="4jnZTahjrDR" role="1tU5fm">
+          <ref role="ehGHo" to="85g0:Juyp1w2Jt3" resolve="Worksheet" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4jnZTahhkj2" role="jymVt" />
+    <node concept="2YIFZL" id="4jnZTahfw1U" role="jymVt">
+      <property role="TrG5h" value="compileStatement" />
+      <property role="od$2w" value="false" />
+      <property role="DiZV1" value="false" />
+      <property role="2aFKle" value="false" />
+      <node concept="3clFbS" id="4jnZTahfw1X" role="3clF47">
+        <node concept="3cpWs6" id="1jnDHv_v_RJ" role="3cqZAp">
+          <node concept="10Nm6u" id="1jnDHv_v_Sa" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4jnZTahfvTe" role="1B3o_S" />
+      <node concept="3Tqbb2" id="4jnZTahfvTw" role="3clF45">
+        <ref role="ehGHo" to="tpee:fzclF8l" resolve="Statement" />
+      </node>
+      <node concept="37vLTG" id="4jnZTahfw2j" role="3clF46">
+        <property role="TrG5h" value="input" />
+        <property role="3TUv4t" value="false" />
+        <node concept="3Tqbb2" id="4jnZTahfw2i" role="1tU5fm">
+          <ref role="ehGHo" to="85g0:Juyp1w2Jte" resolve="Statement" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4jnZTahfwbU" role="jymVt" />
+    <node concept="2YIFZL" id="4jnZTahfwb3" role="jymVt">
+      <property role="TrG5h" value="compileExpression" />
+      <property role="od$2w" value="false" />
+      <property role="DiZV1" value="false" />
+      <property role="2aFKle" value="false" />
+      <node concept="3clFbS" id="4jnZTahfwb4" role="3clF47">
+        <node concept="3cpWs6" id="1jnDHv_vAbp" role="3cqZAp">
+          <node concept="10Nm6u" id="1jnDHv_vAcj" role="3cqZAk" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="4jnZTahfwb8" role="1B3o_S" />
+      <node concept="3Tqbb2" id="4jnZTahfwb9" role="3clF45">
+        <ref role="ehGHo" to="tpee:fz3vP1J" resolve="Expression" />
+      </node>
+      <node concept="37vLTG" id="4jnZTahfwba" role="3clF46">
+        <property role="TrG5h" value="input" />
+        <property role="3TUv4t" value="false" />
+        <node concept="3Tqbb2" id="4jnZTahfwbb" role="1tU5fm">
+          <ref role="ehGHo" to="85g0:Juyp1w2LZ5" resolve="Expression" />
+        </node>
+      </node>
+    </node>
+    <node concept="2tJIrI" id="4jnZTahfvSS" role="jymVt" />
+    <node concept="3Tm1VV" id="4jnZTahfvSq" role="1B3o_S" />
+  </node>
+</model>
+

--- a/mps-workshop-2-itemis/solutions/mps.workshop.runtime/mps.workshop.runtime.msd
+++ b/mps-workshop-2-itemis/solutions/mps.workshop.runtime/mps.workshop.runtime.msd
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="mps.workshop.runtime" uuid="e456fa2c-72f7-4cd4-a691-9b5511b7df4d" moduleVersion="0" compileInMPS="true">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <sourcePath />
+  <dependencies>
+    <dependency reexport="false">f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)</dependency>
+    <dependency reexport="false">c9c683f9-1916-4ea4-bc6e-ec5b2a10659d(mps.workshop.lang)</dependency>
+  </dependencies>
+  <languageVersions>
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="5" />
+    <language slang="l:fd392034-7849-419d-9071-12563d152375:jetbrains.mps.baseLanguage.closures" version="0" />
+    <language slang="l:83888646-71ce-4f1c-9c53-c54016f6ad4f:jetbrains.mps.baseLanguage.collections" version="0" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="1" />
+    <language slang="l:3a13115c-633c-4c5c-bbcc-75c4219e9555:jetbrains.mps.lang.quotation" version="0" />
+    <language slang="l:7866978e-a0f0-4cc7-81bc-4d213d9375e1:jetbrains.mps.lang.smodel" version="8" />
+    <language slang="l:c72da2b9-7cce-4447-8389-f407dc1158b7:jetbrains.mps.lang.structure" version="6" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+    <language slang="l:7a5dda62-9140-4668-ab76-d5ed1746f2b2:jetbrains.mps.lang.typesystem" version="1" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
+    <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+    <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+    <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+    <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
+    <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+    <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
+    <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
+    <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
+    <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+    <module reference="c9c683f9-1916-4ea4-bc6e-ec5b2a10659d(mps.workshop.lang)" version="0" />
+    <module reference="e456fa2c-72f7-4cd4-a691-9b5511b7df4d(mps.workshop.runtime)" version="0" />
+  </dependencyVersions>
+</solution>
+

--- a/mps-workshop-2-itemis/tests/mps.workshop.test/models/plugin.mps
+++ b/mps-workshop-2-itemis/tests/mps.workshop.test/models/plugin.mps
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<model ref="r:f1c06d61-f783-4105-80aa-fa0228224479(mps.workshop.test.plugin)">
+  <persistence version="9" />
+  <languages>
+    <use id="c9c683f9-1916-4ea4-bc6e-ec5b2a10659d" name="mps.workshop.lang" version="0" />
+    <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="5" />
+  </languages>
+  <imports />
+  <registry>
+    <language id="c9c683f9-1916-4ea4-bc6e-ec5b2a10659d" name="mps.workshop.lang">
+      <concept id="855272232427158454" name="mps.workshop.lang.structure.ParensExpression" flags="ng" index="1FNv8A">
+        <child id="855272232427158458" name="expression" index="1FNv8E" />
+      </concept>
+      <concept id="855272232427031612" name="mps.workshop.lang.structure.PlusExpression" flags="ng" index="1FNKmG" />
+      <concept id="855272232427031658" name="mps.workshop.lang.structure.MinusExpression" flags="ng" index="1FNKnU" />
+      <concept id="855272232427032244" name="mps.workshop.lang.structure.MulExpression" flags="ng" index="1FNKs$" />
+      <concept id="855272232427033738" name="mps.workshop.lang.structure.DivExpression" flags="ng" index="1FNLOq" />
+      <concept id="855272232426839413" name="mps.workshop.lang.structure.BinaryExpression" flags="ng" index="1FO1j_">
+        <child id="855272232426839417" name="left" index="1FO1jD" />
+        <child id="855272232426839420" name="right" index="1FO1jG" />
+      </concept>
+      <concept id="855272232426600272" name="mps.workshop.lang.structure.VariableDeclaration" flags="ng" index="1FP7V0">
+        <child id="855272232426610630" name="initializer" index="1FPppm" />
+      </concept>
+      <concept id="855272232426600273" name="mps.workshop.lang.structure.ExpressionStatement" flags="ng" index="1FP7V1">
+        <child id="855272232426610702" name="expression" index="1FPqAu" />
+      </concept>
+      <concept id="855272232426600259" name="mps.workshop.lang.structure.Worksheet" flags="ng" index="1FP7Vj">
+        <child id="855272232426600274" name="statements" index="1FP7V2" />
+      </concept>
+      <concept id="855272232426600271" name="mps.workshop.lang.structure.EmptyStatement" flags="ng" index="1FP7Vv" />
+      <concept id="855272232426640515" name="mps.workshop.lang.structure.NumberLiteral" flags="ng" index="1FPhOj">
+        <property id="855272232426640519" name="value" index="1FPhOn" />
+      </concept>
+    </language>
+    <language id="ceab5195-25ea-4f22-9b92-103b95ca8c0c" name="jetbrains.mps.lang.core">
+      <concept id="1169194658468" name="jetbrains.mps.lang.core.structure.INamedConcept" flags="ng" index="TrEIO">
+        <property id="1169194664001" name="name" index="TrG5h" />
+      </concept>
+    </language>
+  </registry>
+  <node concept="1FP7Vj" id="Juyp1w2L9W">
+    <property role="TrG5h" value="Day 1" />
+    <node concept="1FP7Vv" id="Juyp1w2LYM" role="1FP7V2" />
+    <node concept="1FP7V0" id="Juyp1w2MDw" role="1FP7V2">
+      <property role="TrG5h" value="a" />
+      <node concept="1FPhOj" id="Juyp1w2WZQ" role="1FPppm">
+        <property role="1FPhOn" value="12" />
+      </node>
+    </node>
+    <node concept="1FP7V0" id="Juyp1w2MIA" role="1FP7V2">
+      <property role="TrG5h" value="b" />
+      <node concept="1FNKnU" id="Juyp1w4Kjo" role="1FPppm">
+        <node concept="1FNKmG" id="Juyp1w4Kjp" role="1FO1jD">
+          <node concept="1FNKmG" id="Juyp1w4Kjq" role="1FO1jD">
+            <node concept="1FPhOj" id="Juyp1w4Ju2" role="1FO1jD">
+              <property role="1FPhOn" value="4" />
+            </node>
+            <node concept="1FPhOj" id="Juyp1w4Jub" role="1FO1jG">
+              <property role="1FPhOn" value="5" />
+            </node>
+          </node>
+          <node concept="1FNLOq" id="Juyp1w4Kjr" role="1FO1jG">
+            <node concept="1FNKs$" id="Juyp1w4Kjs" role="1FO1jD">
+              <node concept="1FNKs$" id="Juyp1w4Kjt" role="1FO1jD">
+                <node concept="1FPhOj" id="Juyp1w4Jum" role="1FO1jD">
+                  <property role="1FPhOn" value="4" />
+                </node>
+                <node concept="1FPhOj" id="Juyp1w4Juu" role="1FO1jG">
+                  <property role="1FPhOn" value="1" />
+                </node>
+              </node>
+              <node concept="1FPhOj" id="Juyp1w4JuI" role="1FO1jG">
+                <property role="1FPhOn" value="6" />
+              </node>
+            </node>
+            <node concept="1FPhOj" id="Juyp1w4JVy" role="1FO1jG">
+              <property role="1FPhOn" value="9" />
+            </node>
+          </node>
+        </node>
+        <node concept="1FPhOj" id="Juyp1w4Kol" role="1FO1jG">
+          <property role="1FPhOn" value="12" />
+        </node>
+      </node>
+    </node>
+    <node concept="1FP7V1" id="Juyp1w3C1a" role="1FP7V2">
+      <node concept="1FNKmG" id="Juyp1w875C" role="1FPqAu">
+        <node concept="1FNKmG" id="Juyp1w875D" role="1FO1jD">
+          <node concept="1FPhOj" id="Juyp1w870H" role="1FO1jD">
+            <property role="1FPhOn" value="12" />
+          </node>
+          <node concept="1FPhOj" id="Juyp1w870P" role="1FO1jG">
+            <property role="1FPhOn" value="12" />
+          </node>
+        </node>
+        <node concept="1FNv8A" id="Juyp1w875E" role="1FO1jG">
+          <node concept="1FNLOq" id="Juyp1w875F" role="1FNv8E">
+            <node concept="1FPhOj" id="Juyp1w8719" role="1FO1jD">
+              <property role="1FPhOn" value="12" />
+            </node>
+            <node concept="1FNv8A" id="Juyp1w875G" role="1FO1jG">
+              <node concept="1FNKmG" id="Juyp1w875H" role="1FNv8E">
+                <node concept="1FPhOj" id="Juyp1w871k" role="1FO1jD">
+                  <property role="1FPhOn" value="56" />
+                </node>
+                <node concept="1FPhOj" id="Juyp1w875o" role="1FO1jG">
+                  <property role="1FPhOn" value="34" />
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+    </node>
+    <node concept="1FP7Vv" id="Juyp1w2MIG" role="1FP7V2" />
+    <node concept="1FP7Vv" id="Juyp1w2LYQ" role="1FP7V2" />
+  </node>
+</model>
+

--- a/mps-workshop-2-itemis/tests/mps.workshop.test/mps.workshop.test.msd
+++ b/mps-workshop-2-itemis/tests/mps.workshop.test/mps.workshop.test.msd
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<solution name="mps.workshop.test" uuid="4a6a9476-b593-4e76-9013-34d6c599db0e" moduleVersion="0" compileInMPS="true">
+  <models>
+    <modelRoot contentPath="${module}" type="default">
+      <sourceRoot location="models" />
+    </modelRoot>
+  </models>
+  <sourcePath />
+  <languageVersions>
+    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="5" />
+    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="1" />
+    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
+    <language slang="l:c9c683f9-1916-4ea4-bc6e-ec5b2a10659d:mps.workshop.lang" version="0" />
+  </languageVersions>
+  <dependencyVersions>
+    <module reference="4a6a9476-b593-4e76-9013-34d6c599db0e(mps.workshop.test)" version="0" />
+  </dependencyVersions>
+</solution>
+


### PR DESCRIPTION
Added a interpreter skeleton to the second day as copy of the original one. The idea is that participants would fill the gabs in the interpreter, most of the evaluators are already there but their implementation is just a stub. 

When participants have introduced the string types and binary comparison operations they will have to add these evaluators as well. Before starting the task participants will get a short intro to the interpreter DSL and how it can interact with the type system. 

All the required infrastructure to execute the interpreter is already in place, it will also handle failures from the interpreter runtime. 

The final goal is to show the result of each statement next to it as a read only representation. 